### PR TITLE
Revamp city experiences UI

### DIFF
--- a/app/city/[cityId]/book.tsx
+++ b/app/city/[cityId]/book.tsx
@@ -1,6 +1,17 @@
 import { useLocalSearchParams } from "expo-router";
+import { LinearGradient } from "expo-linear-gradient";
 import { useState } from "react";
-import { Alert, StyleSheet, Text, TextInput, TouchableOpacity, View } from "react-native";
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import { db } from "../../../lib/db";
 
 export default function BookHotel() {
@@ -42,63 +53,116 @@ export default function BookHotel() {
 
 
   return (
-    <View style={s.wrap}>
-      {/* ✅ Heading changed */}
-      <Text style={s.title}>Book a Hotel in {city}</Text>
+    <LinearGradient colors={["#0f172a", "#0b1120", "#020617"]} style={s.gradient}>
+      <KeyboardAvoidingView style={s.flex} behavior={Platform.OS === "ios" ? "padding" : undefined}>
+        <ScrollView
+          contentContainerStyle={s.scroll}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <View style={s.hero}>
+            <View style={s.heroAccent} />
+            <Text style={s.eyebrow}>Stay in style</Text>
+            <Text style={s.title}>Book a Hotel in {city}</Text>
+            <Text style={s.subtitle}>Personalize your stay with our curated partner properties.</Text>
+          </View>
 
-      <TextInput
-        style={s.input}
-        placeholder="Your Name"
-        placeholderTextColor="#555"
-        value={name}
-        onChangeText={setName}
-      />
-      <TextInput
-        style={s.input}
-        placeholder="Your Address"
-        placeholderTextColor="#555"
-        value={address}
-        onChangeText={setAddress}
-      />
-      <TextInput
-        style={s.input}
-        placeholder="Start Date (YYYY-MM-DD)"
-        placeholderTextColor="#555"
-        value={start}
-        onChangeText={setStart}
-      />
-      <TextInput
-        style={s.input}
-        placeholder="End Date (YYYY-MM-DD)"
-        placeholderTextColor="#555"
-        value={end}
-        onChangeText={setEnd}
-      />
+          <View style={s.formCard}>
+            <Text style={s.formLabel}>Guest details</Text>
+            <TextInput
+              style={s.input}
+              placeholder="Your Name"
+              placeholderTextColor="rgba(148, 163, 184, 0.8)"
+              value={name}
+              onChangeText={setName}
+            />
+            <TextInput
+              style={s.input}
+              placeholder="Your Address"
+              placeholderTextColor="rgba(148, 163, 184, 0.8)"
+              value={address}
+              onChangeText={setAddress}
+            />
+          </View>
 
-      <TouchableOpacity style={s.btn} onPress={saveBooking}>
-        <Text style={s.btnText}>Confirm Booking</Text>
-      </TouchableOpacity>
-    </View>
+          <View style={s.formCard}>
+            <Text style={s.formLabel}>Stay dates</Text>
+            <TextInput
+              style={s.input}
+              placeholder="Start Date (YYYY-MM-DD)"
+              placeholderTextColor="rgba(148, 163, 184, 0.8)"
+              value={start}
+              onChangeText={setStart}
+            />
+            <TextInput
+              style={s.input}
+              placeholder="End Date (YYYY-MM-DD)"
+              placeholderTextColor="rgba(148, 163, 184, 0.8)"
+              value={end}
+              onChangeText={setEnd}
+            />
+          </View>
+
+          <TouchableOpacity style={s.button} activeOpacity={0.9} onPress={saveBooking}>
+            <LinearGradient colors={["#ec4899", "#d946ef"]} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={s.buttonGradient}>
+              <Text style={s.buttonText}>Confirm Booking</Text>
+              <Text style={s.buttonHint}>Instant confirmation, no booking fees.</Text>
+            </LinearGradient>
+          </TouchableOpacity>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </LinearGradient>
   );
 }
 
 const s = StyleSheet.create({
-  wrap: { flex: 1, padding: 16 },
-  title: { fontSize: 20, fontWeight: "700", marginBottom: 12 },
-  input: {
+  gradient: { flex: 1 },
+  flex: { flex: 1 },
+  scroll: { padding: 24, paddingBottom: 60 },
+  hero: {
+    backgroundColor: "rgba(15, 23, 42, 0.7)",
+    borderRadius: 28,
+    padding: 24,
     borderWidth: 1,
-    borderColor: "#ccc",
-    padding: 10,
-    marginBottom: 10,
-    borderRadius: 8,
+    borderColor: "rgba(148, 163, 184, 0.18)",
+    marginBottom: 24,
+    overflow: "hidden",
+  },
+  heroAccent: {
+    position: "absolute",
+    width: 220,
+    height: 220,
+    backgroundColor: "#ec4899",
+    opacity: 0.18,
+    borderRadius: 160,
+    right: -80,
+    top: -100,
+  },
+  eyebrow: { color: "#f472b6", textTransform: "uppercase", fontSize: 12, letterSpacing: 2, marginBottom: 8 },
+  title: { fontSize: 30, fontWeight: "800", color: "#f8fafc" },
+  subtitle: { color: "#cbd5e1", marginTop: 10, lineHeight: 20 },
+  formCard: {
+    backgroundColor: "rgba(15, 23, 42, 0.75)",
+    borderRadius: 24,
+    padding: 20,
+    borderWidth: 1,
+    borderColor: "rgba(148, 163, 184, 0.2)",
+    marginBottom: 20,
+  },
+  formLabel: { color: "#f8fafc", fontWeight: "700", fontSize: 16, marginBottom: 14 },
+  input: {
+    backgroundColor: "rgba(15, 23, 42, 0.92)",
+    borderRadius: 16,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderWidth: 1,
+    borderColor: "rgba(148, 163, 184, 0.2)",
+    color: "#f8fafc",
     fontSize: 16,
-    color: "#000",
+    marginBottom: 12,
   },
-  btn: {
-    backgroundColor: "#007AFF",
-    padding: 14,
-    borderRadius: 8,
-    alignItems: "center",
-  },
-  btnText: { color: "#fff", fontWeight: "700", fontSize: 16 },
+  button: { borderRadius: 24, overflow: "hidden" },
+  buttonGradient: { padding: 20, alignItems: "center" },
+  buttonText: { color: "#f8fafc", fontSize: 18, fontWeight: "700" },
+  buttonHint: { color: "#fdf2f8", marginTop: 6, fontSize: 13, opacity: 0.9 },
 });

--- a/app/city/[cityId]/events.tsx
+++ b/app/city/[cityId]/events.tsx
@@ -1,7 +1,8 @@
 // app/city/[cityId]/events.tsx
 import { useLocalSearchParams } from "expo-router";
 import React, { useMemo } from "react";
-import { FlatList, StyleSheet, Text, View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { FlatList, SafeAreaView, StatusBar, StyleSheet, Text, View } from "react-native";
 import { CITY_DATA } from "./index"; // ✅ import from index.tsx
 
 export default function EventsScreen() {
@@ -15,52 +16,93 @@ export default function EventsScreen() {
 
   if (!city) {
     return (
-      <View style={s.wrap}>
-        <Text style={s.h1}>No data for {cityName || cityId}</Text>
-      </View>
+      <LinearGradient colors={["#0f172a", "#0b1120", "#020617"]} style={s.gradient}>
+        <StatusBar barStyle="light-content" />
+        <SafeAreaView style={s.safe}>
+          <View style={s.centerBox}>
+            <Text style={s.h1}>No data for {cityName || cityId}</Text>
+            <Text style={s.subtitle}>Try selecting another destination from the explore tab.</Text>
+          </View>
+        </SafeAreaView>
+      </LinearGradient>
     );
   }
 
   if (events.length === 0) {
     return (
-      <View style={s.wrap}>
-        <Text style={s.h1}>Events in {city.name}</Text>
-        <Text style={{ opacity: 0.7, marginTop: 10 }}>No events available.</Text>
-      </View>
+      <LinearGradient colors={["#0f172a", "#0b1120", "#020617"]} style={s.gradient}>
+        <StatusBar barStyle="light-content" />
+        <SafeAreaView style={s.safe}>
+          <View style={s.centerBox}>
+            <Text style={s.h1}>Events in {city.name}</Text>
+            <Text style={s.subtitle}>We’re curating experiences here. Check back soon!</Text>
+          </View>
+        </SafeAreaView>
+      </LinearGradient>
     );
   }
 
   return (
-    <View style={s.wrap}>
-      <Text style={s.h1}>🎉 Events in {city.name}</Text>
-
-      <FlatList
-        data={events}
-        keyExtractor={(item) => item.id}
-        ItemSeparatorComponent={() => <View style={{ height: 12 }} />}
-        renderItem={({ item }) => (
-          <View style={s.card}>
-            <Text style={s.title}>{item.title}</Text>
-            <Text style={s.date}>📅 {item.date}</Text>
-            {!!item.desc && <Text style={s.desc}>{item.desc}</Text>}
-          </View>
-        )}
-      />
-    </View>
+    <LinearGradient colors={["#0f172a", "#0b1120", "#020617"]} style={s.gradient}>
+      <StatusBar barStyle="light-content" />
+      <SafeAreaView style={s.safe}>
+        <FlatList
+          contentContainerStyle={s.list}
+          data={events}
+          keyExtractor={(item) => item.id}
+          showsVerticalScrollIndicator={false}
+          ListHeaderComponent={() => (
+            <View style={s.header}>
+              <Text style={s.h1}>🎉 Events in {city.name}</Text>
+              <Text style={s.subtitle}>Make plans with hand-picked gatherings and unforgettable nights out.</Text>
+            </View>
+          )}
+          ItemSeparatorComponent={() => <View style={{ height: 18 }} />}
+          renderItem={({ item }) => (
+            <View style={s.card}>
+              <LinearGradient
+                colors={["#1d4ed8", "#9333ea"]}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 1 }}
+                style={s.cardAccent}
+              />
+              <Text style={s.title}>{item.title}</Text>
+              <Text style={s.date}>{`📅\n${item.date}`}</Text>
+              {!!item.desc && <Text style={s.desc}>{item.desc}</Text>}
+            </View>
+          )}
+        />
+      </SafeAreaView>
+    </LinearGradient>
   );
 }
 
 const s = StyleSheet.create({
-  wrap: { flex: 1, padding: 16 },
-  h1: { fontSize: 22, fontWeight: "700", marginBottom: 16 },
+  gradient: { flex: 1 },
+  safe: { flex: 1 },
+  list: { padding: 24, paddingBottom: 48 },
+  header: { marginBottom: 12 },
+  h1: { fontSize: 28, fontWeight: "800", color: "#f8fafc" },
+  subtitle: { color: "#94a3b8", marginTop: 10, lineHeight: 20 },
+  centerBox: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },
   card: {
+    backgroundColor: "rgba(15, 23, 42, 0.85)",
+    borderRadius: 24,
+    padding: 22,
     borderWidth: 1,
-    borderColor: "#ccc",
-    borderRadius: 10,
-    padding: 14,
-    backgroundColor: "#f9f9f9",
+    borderColor: "rgba(148, 163, 184, 0.2)",
+    overflow: "hidden",
   },
-  title: { fontSize: 16, fontWeight: "600", marginBottom: 6 },
-  date: { fontSize: 14, fontWeight: "500", color: "#333", marginBottom: 6 },
-  desc: { fontSize: 14, color: "#555" },
+  cardAccent: {
+    position: "absolute",
+    top: -40,
+    right: -60,
+    width: 180,
+    height: 180,
+    opacity: 0.2,
+    borderRadius: 999,
+  },
+  title: { fontSize: 20, fontWeight: "700", color: "#f8fafc", marginBottom: 12 },
+  date: { color: "#bfdbfe", fontWeight: "600", fontSize: 15, marginBottom: 12, lineHeight: 20 },
+  desc: { color: "#cbd5e1", lineHeight: 20 },
 });

--- a/app/city/[cityId]/index.tsx
+++ b/app/city/[cityId]/index.tsx
@@ -1,7 +1,8 @@
 // app/city/[cityId]/index.tsx
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useMemo } from "react";
-import { FlatList, Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { Image, SafeAreaView, ScrollView, StatusBar, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import MapView, { Marker } from "react-native-maps";
 
 type Place = {
@@ -392,119 +393,222 @@ export default function CityScreen() {
     : undefined;
 
   return (
-    <View style={s.wrap}>
-      <Text style={s.h1}>{city.name}</Text>
-      <Text style={s.sub}>Top attractions</Text>
-
-      {initialRegion && (
-        <MapView style={s.map} initialRegion={initialRegion}>
-          {places.map((p) => (
-            <Marker key={p.id} coordinate={p.coords} title={p.name} description={p.desc || ""} />
-          ))}
-        </MapView>
-      )}
-
-      <FlatList
-        data={places}
-        keyExtractor={(i) => i.id}
-        ItemSeparatorComponent={() => <View style={{ height: 10 }} />}
-        renderItem={({ item }) => (
-          <TouchableOpacity
-            style={s.card}
-            activeOpacity={0.9}
-            onPress={() =>
-              router.push(
-                `/city/${slug}/place/${item.id}?name=${encodeURIComponent(item.name)}&lat=${item.coords.latitude}&lon=${item.coords.longitude}&cityName=${encodeURIComponent(city.name)}&country=${encodeURIComponent(city.country)}&desc=${encodeURIComponent(item.desc ?? "")}`
-              )
-            }
-          >
-            <Image source={item.img || PLACEHOLDER} style={s.thumb} resizeMode="cover" />
-            <View style={{ flex: 1 }}>
-              <Text style={s.title}>{item.name}</Text>
-              {!!item.desc && <Text style={s.desc} numberOfLines={2}>{item.desc}</Text>}
+    <LinearGradient colors={["#0f172a", "#111c2d", "#060b19"]} style={s.gradient}>
+      <StatusBar barStyle="light-content" />
+      <SafeAreaView style={s.safe}>
+        <ScrollView contentContainerStyle={s.scroll} showsVerticalScrollIndicator={false}>
+          <View style={s.hero}>
+            <View style={s.heroGlow} />
+            <Text style={s.heroEyebrow}>Discover</Text>
+            <Text style={s.heroTitle}>{city.name}</Text>
+            <Text style={s.heroSubtitle}>{city.country}</Text>
+            <View style={s.heroBadge}>
+              <Text style={s.heroBadgeText}>Curated escapes</Text>
             </View>
-          </TouchableOpacity>
-        )}
-      />
+          </View>
 
-      {/* Events button (shows only if events exist) */}
-      {city.events && city.events.length > 0 && (
-        <TouchableOpacity
-          style={[s.card, { marginTop: 20, backgroundColor: "#eef" }]}
-          onPress={() => router.push(`/city/${slug}/events?cityName=${encodeURIComponent(city.name)}`)}
-        >
-          <Text style={{ fontWeight: "700", fontSize: 16 }}>🎉 View Events in {city.name}</Text>
-        </TouchableOpacity>
-      )}
+          {initialRegion && (
+            <View style={s.mapShell}>
+              <MapView style={s.map} initialRegion={initialRegion}>
+                {places.map((p) => (
+                  <Marker key={p.id} coordinate={p.coords} title={p.name} description={p.desc || ""} />
+                ))}
+              </MapView>
+            </View>
+          )}
 
+          <View style={s.sectionHeader}>
+            <Text style={s.sectionTitle}>Must-see spots</Text>
+            <Text style={s.sectionSubtitle}>Hand-picked highlights to make the most of your stay.</Text>
+          </View>
 
+          <View style={s.places}>
+            {places.map((item) => (
+              <TouchableOpacity
+                key={item.id}
+                activeOpacity={0.9}
+                style={s.placeCard}
+                onPress={() =>
+                  router.push(
+                    `/city/${slug}/place/${item.id}?name=${encodeURIComponent(item.name)}&lat=${item.coords.latitude}&lon=${item.coords.longitude}&cityName=${encodeURIComponent(city.name)}&country=${encodeURIComponent(city.country)}&desc=${encodeURIComponent(item.desc ?? "")}`
+                  )
+                }
+              >
+                <Image source={item.img || PLACEHOLDER} style={s.placeImage} resizeMode="cover" />
+                <View style={s.placeContent}>
+                  <Text style={s.placeName}>{item.name}</Text>
+                  {!!item.desc && (
+                    <Text style={s.placeDesc} numberOfLines={2}>
+                      {item.desc}
+                    </Text>
+                  )}
+                  <View style={s.placeMeta}>
+                    <Text style={s.placeMetaText}>Tap to explore details</Text>
+                  </View>
+                </View>
+              </TouchableOpacity>
+            ))}
+          </View>
 
+          <View style={s.sectionHeader}>
+            <Text style={s.sectionTitle}>Plan your trip</Text>
+            <Text style={s.sectionSubtitle}>Quick access to everything you need.</Text>
+          </View>
 
-      {city && (//yhaaaa lagaya h
-  <TouchableOpacity
-    style={[s.card, { marginTop: 20, backgroundColor: "#efe" }]}
-    onPress={() =>
-      router.push(`/city/${slug}/transport?cityName=${encodeURIComponent(city.name)}`)
-    }
-  >
-    <Text style={{ fontWeight: "700", fontSize: 16 }}>
-      🚍 View Transportation in {city.name}
-    </Text> 
-  </TouchableOpacity>
-  
+          <View style={s.actions}>
+            {city.events && city.events.length > 0 && (
+              <TouchableOpacity
+                activeOpacity={0.9}
+                style={s.actionCard}
+                onPress={() => router.push(`/city/${slug}/events?cityName=${encodeURIComponent(city.name)}`)}
+              >
+                <LinearGradient colors={["#4338ca", "#2563eb"]} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={s.actionGradient}>
+                  <Text style={s.actionEmoji}>🎉</Text>
+                  <View style={{ flex: 1 }}>
+                    <Text style={s.actionTitle}>See upcoming events</Text>
+                    <Text style={s.actionSubtitle}>Find experiences happening while you’re in town.</Text>
+                  </View>
+                </LinearGradient>
+              </TouchableOpacity>
+            )}
 
-  
-)}  
+            <TouchableOpacity
+              activeOpacity={0.9}
+              style={s.actionCard}
+              onPress={() =>
+                router.push(`/city/${slug}/transport?cityName=${encodeURIComponent(city.name)}`)
+              }
+            >
+              <LinearGradient colors={["#0891b2", "#0ea5e9"]} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={s.actionGradient}>
+                <Text style={s.actionEmoji}>🚍</Text>
+                <View style={{ flex: 1 }}>
+                  <Text style={s.actionTitle}>Navigate the city</Text>
+                  <Text style={s.actionSubtitle}>Transit tips and ways to get around with ease.</Text>
+                </View>
+              </LinearGradient>
+            </TouchableOpacity>
 
-<TouchableOpacity
-  style={[s.card, { marginTop: 20, backgroundColor: "#ffe" }]}
-  onPress={() =>
-    router.push({
-      pathname: "/city/[cityId]/book",
-      params: {
-        cityId: slug,          // city id
-        hotel: "Sample Hotel", // static test hotel
-        city: city.name,       // actual city name
-      },
-    })
-  }
->
-  <Text style={{ fontWeight: "700", fontSize: 16 }}>
-    📅 Book a Hotel in {city.name}
-  </Text>
-</TouchableOpacity>
+            <TouchableOpacity
+              activeOpacity={0.9}
+              style={s.actionCard}
+              onPress={() =>
+                router.push({
+                  pathname: "/city/[cityId]/book",
+                  params: {
+                    cityId: slug,
+                    hotel: "Sample Hotel",
+                    city: city.name,
+                  },
+                })
+              }
+            >
+              <LinearGradient colors={["#d946ef", "#ec4899"]} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={s.actionGradient}>
+                <Text style={s.actionEmoji}>🏨</Text>
+                <View style={{ flex: 1 }}>
+                  <Text style={s.actionTitle}>Book a stay</Text>
+                  <Text style={s.actionSubtitle}>Reserve hand-picked hotels in just a few taps.</Text>
+                </View>
+              </LinearGradient>
+            </TouchableOpacity>
 
-
-
-<TouchableOpacity
-  style={[s.card, { marginTop: 20, backgroundColor: "#fef" }]}
-  onPress={() => router.push(`/city/${slug}/bookings`)}
->
-  <Text style={{ fontWeight: "700", fontSize: 16 }}>
-    📖 View Bookings in {city.name}
-  </Text>
-</TouchableOpacity>
-
-
-
-    </View>
+            <TouchableOpacity
+              activeOpacity={0.9}
+              style={s.actionCard}
+              onPress={() => router.push(`/city/${slug}/bookings`)}
+            >
+              <LinearGradient colors={["#14b8a6", "#22c55e"]} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={s.actionGradient}>
+                <Text style={s.actionEmoji}>📖</Text>
+                <View style={{ flex: 1 }}>
+                  <Text style={s.actionTitle}>View your bookings</Text>
+                  <Text style={s.actionSubtitle}>Keep tabs on every reservation in one place.</Text>
+                </View>
+              </LinearGradient>
+            </TouchableOpacity>
+          </View>
+        </ScrollView>
+      </SafeAreaView>
+    </LinearGradient>
   );
 }
 
 const s = StyleSheet.create({
-  wrap: { flex: 1, padding: 16 },
-  h1: { fontSize: 22, fontWeight: "700" },
-  sub: { opacity: 0.7, marginBottom: 12 },
-  map: { height: 180, borderRadius: 12, marginBottom: 12 },
-  card: {
+  gradient: { flex: 1 },
+  safe: { flex: 1 },
+  scroll: { padding: 24, paddingBottom: 80 },
+  hero: {
+    backgroundColor: "rgba(15, 23, 42, 0.65)",
+    borderRadius: 28,
+    padding: 24,
     borderWidth: 1,
-    borderRadius: 12,
-    padding: 12,
+    borderColor: "rgba(148, 163, 184, 0.18)",
+    overflow: "hidden",
+    marginBottom: 28,
+  },
+  heroGlow: {
+    position: "absolute",
+    width: 220,
+    height: 220,
+    backgroundColor: "#38bdf8",
+    opacity: 0.18,
+    borderRadius: 160,
+    right: -80,
+    top: -120,
+  },
+  heroEyebrow: { color: "#94a3b8", textTransform: "uppercase", letterSpacing: 1.5, fontSize: 12, marginBottom: 10 },
+  heroTitle: { fontSize: 34, fontWeight: "800", color: "#f8fafc" },
+  heroSubtitle: { fontSize: 18, color: "#cbd5f5", marginTop: 6 },
+  heroBadge: {
+    alignSelf: "flex-start",
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+    borderRadius: 999,
+    backgroundColor: "rgba(59, 130, 246, 0.15)",
+    borderWidth: 1,
+    borderColor: "rgba(59, 130, 246, 0.35)",
+    marginTop: 18,
+  },
+  heroBadgeText: { color: "#bfdbfe", fontSize: 13, fontWeight: "600" },
+  mapShell: {
+    borderRadius: 24,
+    overflow: "hidden",
+    height: 220,
+    borderWidth: 1,
+    borderColor: "rgba(148, 163, 184, 0.25)",
+    marginBottom: 28,
+    backgroundColor: "rgba(15, 23, 42, 0.75)",
+  },
+  map: { flex: 1 },
+  sectionHeader: { marginBottom: 16 },
+  sectionTitle: { fontSize: 22, fontWeight: "700", color: "#f1f5f9" },
+  sectionSubtitle: { color: "#94a3b8", marginTop: 6, lineHeight: 20 },
+  places: { gap: 16, marginBottom: 32 },
+  placeCard: {
+    backgroundColor: "rgba(15, 23, 42, 0.75)",
+    borderRadius: 24,
+    borderWidth: 1,
+    borderColor: "rgba(148, 163, 184, 0.18)",
+    overflow: "hidden",
+  },
+  placeImage: { width: "100%", height: 190 },
+  placeContent: { padding: 18, gap: 10 },
+  placeName: { fontSize: 20, fontWeight: "700", color: "#f8fafc" },
+  placeDesc: { color: "#cbd5e1", lineHeight: 20 },
+  placeMeta: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 12,
+    gap: 6,
+    paddingVertical: 6,
   },
-  thumb: { width: 72, height: 72, borderRadius: 10, backgroundColor: "#F2F2F2" },
-  title: { fontWeight: "600", marginBottom: 4 },
-  desc: { opacity: 0.6 },
+  placeMetaText: { color: "#60a5fa", fontWeight: "600", fontSize: 13, letterSpacing: 0.2 },
+  actions: { gap: 16, marginBottom: 24 },
+  actionCard: { borderRadius: 24, overflow: "hidden" },
+  actionGradient: {
+    padding: 18,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+  },
+  actionEmoji: { fontSize: 28 },
+  actionTitle: { color: "#f8fafc", fontSize: 18, fontWeight: "700", marginBottom: 4 },
+  actionSubtitle: { color: "#e2e8f0", opacity: 0.86, lineHeight: 18 },
 });

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -20,8 +20,9 @@ export default function Hero() {
         style={s.overlay}
       >
         <Text style={s.kicker}>CityHop</Text>
-        <Text style={s.title}>Elevate your travel plans.</Text>
-        <Text style={s.subtitle}>Discover city highlights, hidden gems, and curated stays in one beautiful place.</Text>
+        <Text style={s.lead}>Let’s</Text>
+        <Text style={s.leadAccent}>Destinations today!</Text>
+        <Text style={s.subtitle}>Elevate your travel plans with curated highlights, hidden gems, and boutique stays picked for you.</Text>
         <View style={s.badges}>
           <View style={s.badge}>
             <Feather name="sun" size={14} color={Colors.accent} />
@@ -63,10 +64,16 @@ const s = StyleSheet.create({
     letterSpacing: 2,
     textTransform: "uppercase",
   },
-  title: {
-    color: "#fff",
+  lead: {
+    color: "#F8FAFC",
+    fontWeight: "800",
+    fontSize: 26,
+    letterSpacing: 1,
+  },
+  leadAccent: {
+    color: "#38bdf8",
     fontWeight: "900",
-    fontSize: 28,
+    fontSize: 30,
     lineHeight: 34,
   },
   subtitle: {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -5,3 +5,32 @@ jest.mock("react-native-reanimated", () => {
   Reanimated.default.call = () => {};
   return Reanimated;
 });
+
+jest.mock("expo-linear-gradient", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+
+  return {
+    LinearGradient: ({ children, style }) => React.createElement(View, { style }, children),
+  };
+});
+
+jest.mock("@expo/vector-icons", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
+
+  return {
+    Feather: ({ name = "", color, size = 16, style, ...rest }) =>
+      React.createElement(
+        Text,
+        {
+          ...rest,
+          style: [
+            { color: color ?? "#fff", fontSize: size },
+            style,
+          ],
+        },
+        `Feather:${name}`
+      ),
+  };
+});


### PR DESCRIPTION
## Summary
- redesign the city detail screen with a gradient hero, immersive map card, and CTA tiles
- refresh the events listing with atmospheric gradients, improved empty states, and clearer event details
- overhaul the hotel booking form and add Jest mocks for gradient/vector icons to keep tests passing

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e3008de8148330a3c43532fa531060