### PR TITLE
Add curated restaurant section to city guide

### DIFF
--- a/app/city/[cityId]/index.tsx
+++ b/app/city/[cityId]/index.tsx
@@ -2,7 +2,7 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useMemo } from "react";
 import { LinearGradient } from "expo-linear-gradient";
-import { Image, SafeAreaView, ScrollView, StatusBar, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { Image, ImageBackground, SafeAreaView, ScrollView, StatusBar, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import MapView, { Marker } from "react-native-maps";
 
 type Place = {
@@ -18,7 +18,16 @@ type Event = {
   date: string;
   desc?: string;
 };
-type CityData = { name: string; country: string; places: Place[]; events?: Event[] };
+type Restaurant = {
+  id: string;
+  name: string;
+  cuisine: string;
+  price: string;
+  rating: number;
+  signature: string;
+  img?: any;
+};
+type CityData = { name: string; country: string; places: Place[]; events?: Event[]; restaurants?: Restaurant[] };
 
 
 
@@ -26,6 +35,7 @@ type CityData = { name: string; country: string; places: Place[]; events?: Event
 
 // ✅ fallback image
 const PLACEHOLDER = { uri: "https://picsum.photos/640/360?cityhop" };
+const RESTAURANT_PLACEHOLDER = { uri: "https://images.unsplash.com/photo-1528605248644-14dd04022da1?q=80&w=800" };
 
 // ------------------- CITY DATA (all cities preserved, events added) -------------------
 export const CITY_DATA: Record<string, CityData> = {
@@ -59,8 +69,46 @@ export const CITY_DATA: Record<string, CityData> = {
       { id: "concert1", title: "Royal Albert Concert", date: "2025-10-12", desc: "Classical music festival." },
       { id: "marathon", title: "London Marathon", date: "2025-11-05", desc: "Annual marathon race." },
     ],
+    restaurants: [
+      {
+        id: "dishoom",
+        name: "Dishoom Covent Garden",
+        cuisine: "Bombay comfort food",
+        price: "££",
+        rating: 4.7,
+        signature: "Black daal slow-cooked for 24 hours",
+        img: { uri: "https://images.unsplash.com/photo-1525755662778-989d0524087e?q=80&w=800" },
+      },
+      {
+        id: "padella",
+        name: "Padella",
+        cuisine: "Handmade pasta",
+        price: "££",
+        rating: 4.8,
+        signature: "Pappardelle with eight-hour beef shin ragu",
+        img: { uri: "https://images.unsplash.com/photo-1604908177073-b2c25d4e1b8c?q=80&w=800" },
+      },
+      {
+        id: "sketch",
+        name: "Sketch Lecture Room & Library",
+        cuisine: "Modern French fine dining",
+        price: "££££",
+        rating: 4.6,
+        signature: "Six-course tasting menu in Wes Anderson interiors",
+        img: { uri: "https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?q=80&w=800" },
+      },
+      {
+        id: "borough",
+        name: "Borough Market Tapas",
+        cuisine: "Seasonal small plates",
+        price: "££",
+        rating: 4.5,
+        signature: "Charred octopus with smoked paprika aioli",
+        img: { uri: "https://images.unsplash.com/photo-1525755662778-989d0524087e?q=80&w=800" },
+      },
+    ],
 
-    
+
 
 
 
@@ -95,6 +143,44 @@ export const CITY_DATA: Record<string, CityData> = {
     events: [
       { id: "broadway", title: "Broadway Week", date: "2025-10-18", desc: "Discounted Broadway shows all week." },
     ],
+    restaurants: [
+      {
+        id: "elevenmadison",
+        name: "Eleven Madison Park",
+        cuisine: "Plant-based fine dining",
+        price: "$$$",
+        rating: 4.9,
+        signature: "Seasonal tasting menu in Art Deco grandeur",
+        img: { uri: "https://images.unsplash.com/photo-1552566626-52f8b828add9?q=80&w=800" },
+      },
+      {
+        id: "joe",
+        name: "Joe's Pizza",
+        cuisine: "NY slice shop",
+        price: "$",
+        rating: 4.6,
+        signature: "Classic foldable pepperoni slice",
+        img: { uri: "https://images.unsplash.com/photo-1571987502227-0f9be64d0a43?q=80&w=800" },
+      },
+      {
+        id: "los_tacos",
+        name: "Los Tacos No.1",
+        cuisine: "Mexican street food",
+        price: "$$",
+        rating: 4.8,
+        signature: "Adobada tacos fresh off the plancha",
+        img: { uri: "https://images.unsplash.com/photo-1608032360609-83d707b27bff?q=80&w=800" },
+      },
+      {
+        id: "momofuku",
+        name: "Momofuku Noodle Bar",
+        cuisine: "Modern Asian",
+        price: "$$",
+        rating: 4.5,
+        signature: "Pork belly buns with hoisin glaze",
+        img: { uri: "https://images.unsplash.com/photo-1540189549336-e6e99c3679fe?q=80&w=800" },
+      },
+    ],
   },
 
   wellington: {
@@ -123,24 +209,62 @@ export const CITY_DATA: Record<string, CityData> = {
         img: require("../../../assets/images/w3.jpg"),
       },
     ],
-    events: [ { 
-      id: "filmfest", 
-      title: "New Zealand International Film Festival", 
-      date: "2025-07-15", 
-      desc: "Showcasing international and local films across Wellington cinemas." 
+    events: [ {
+      id: "filmfest",
+      title: "New Zealand International Film Festival",
+      date: "2025-07-15",
+      desc: "Showcasing international and local films across Wellington cinemas."
     },
-    { 
-      id: "cubadupa", 
-      title: "CubaDupa Street Festival", 
-      date: "2025-03-22", 
-      desc: "Annual street festival with live music, dance, art, and food on Cuba Street." 
+    {
+      id: "cubadupa",
+      title: "CubaDupa Street Festival",
+      date: "2025-03-22",
+      desc: "Annual street festival with live music, dance, art, and food on Cuba Street."
     },
-    { 
-      id: "worldofwearableart", 
-      title: "World of WearableArt Show", 
-      date: "2025-09-25", 
-      desc: "Spectacular live show combining fashion, art, and performance." 
-    },], 
+    {
+      id: "worldofwearableart",
+      title: "World of WearableArt Show",
+      date: "2025-09-25",
+      desc: "Spectacular live show combining fashion, art, and performance."
+    },],
+    restaurants: [
+      {
+        id: "hiakai",
+        name: "Hiakai",
+        cuisine: "Modern Māori",
+        price: "$$$",
+        rating: 4.9,
+        signature: "Tasting menu celebrating native ingredients",
+        img: { uri: "https://images.unsplash.com/photo-1499028344343-cd173ffc68a9?q=80&w=800" },
+      },
+      {
+        id: "fidel",
+        name: "Fidel's Cafe",
+        cuisine: "Kiwi brunch",
+        price: "$$",
+        rating: 4.5,
+        signature: "Cuban-style eggs with house-made hash",
+        img: { uri: "https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?q=80&w=800" },
+      },
+      {
+        id: "egmont",
+        name: "Egmont St. Eatery",
+        cuisine: "Seasonal bistro",
+        price: "$$$",
+        rating: 4.7,
+        signature: "Harissa lamb shoulder with kumara",
+        img: { uri: "https://images.unsplash.com/photo-1551218808-94e220e084d2?q=80&w=800" },
+      },
+      {
+        id: "orleans",
+        name: "Orleans",
+        cuisine: "Southern comfort",
+        price: "$$",
+        rating: 4.4,
+        signature: "Buttermilk fried chicken and waffles",
+        img: { uri: "https://images.unsplash.com/photo-1504674900247-0877df9cc836?q=80&w=800" },
+      },
+    ],
   },
 
   paris: {
@@ -173,6 +297,44 @@ export const CITY_DATA: Record<string, CityData> = {
       { id: "fashion", title: "Paris Fashion Week", date: "2025-10-20", desc: "Global fashion week." },
       { id: "wine", title: "Wine Festival", date: "2025-11-15", desc: "Celebration of French wine." },
     ],
+    restaurants: [
+      {
+        id: "le_cinq",
+        name: "Le Cinq",
+        cuisine: "Haute French",
+        price: "€€€€",
+        rating: 4.9,
+        signature: "Blue lobster with citrus beurre blanc",
+        img: { uri: "https://images.unsplash.com/photo-1473093295043-cdd812d0e601?q=80&w=800" },
+      },
+      {
+        id: "septime",
+        name: "Septime",
+        cuisine: "Modern bistronomie",
+        price: "€€€",
+        rating: 4.7,
+        signature: "Seasonal tasting with natural wine pairing",
+        img: { uri: "https://images.unsplash.com/photo-1478145046317-39f10e56b5e9?q=80&w=800" },
+      },
+      {
+        id: "breizh",
+        name: "Breizh Café",
+        cuisine: "Breton crêperie",
+        price: "€€",
+        rating: 4.6,
+        signature: "Buckwheat galette with salted caramel butter",
+        img: { uri: "https://images.unsplash.com/photo-1473093295043-cdd812d0e601?q=80&w=800" },
+      },
+      {
+        id: "pinkmamma",
+        name: "Pink Mamma",
+        cuisine: "Rustic Italian",
+        price: "€€",
+        rating: 4.5,
+        signature: "Truffle pasta served in a wheel of pecorino",
+        img: { uri: "https://images.unsplash.com/photo-1515003197210-e0cd71810b5f?q=80&w=800" },
+      },
+    ],
   },
 
   jaipur: {
@@ -203,6 +365,44 @@ export const CITY_DATA: Record<string, CityData> = {
     ],
     events: [ { id: "festival1", title: "Jaipur Literature Festival", date: "2025-01-28", desc: "World’s largest free literary festival." },
     { id: "festival2", title: "Teej Festival", date: "2025-08-10", desc: "Traditional festival for monsoon with cultural programs." },],
+    restaurants: [
+      {
+        id: "bar_palladio",
+        name: "Bar Palladio",
+        cuisine: "Rajput-European fusion",
+        price: "₹₹₹",
+        rating: 4.7,
+        signature: "Saffron paneer tikka with pistachio pesto",
+        img: { uri: "https://images.unsplash.com/photo-1540189549336-e6e99c3679fe?q=80&w=800" },
+      },
+      {
+        id: "chokhi",
+        name: "Chokhi Dhani",
+        cuisine: "Traditional Rajasthani thali",
+        price: "₹₹",
+        rating: 4.6,
+        signature: "Royal thali with 20+ local delicacies",
+        img: { uri: "https://images.unsplash.com/photo-1555949963-aa79dcee981c?q=80&w=800" },
+      },
+      {
+        id: "tapri",
+        name: "Tapri Central",
+        cuisine: "Chai & street bites",
+        price: "₹₹",
+        rating: 4.5,
+        signature: "Masala chai with ajwain-khari biscuits",
+        img: { uri: "https://images.unsplash.com/photo-1543353071-10c8ba85a904?q=80&w=800" },
+      },
+      {
+        id: "suvarna",
+        name: "Suvarna Mahal",
+        cuisine: "Royal Indian",
+        price: "₹₹₹₹",
+        rating: 4.8,
+        signature: "Laal maas slow-cooked with Mathania chilies",
+        img: { uri: "https://images.unsplash.com/photo-1589308078053-169825f15602?q=80&w=800" },
+      },
+    ],
   },
 
   cherrapunji: {
@@ -233,6 +433,44 @@ export const CITY_DATA: Record<string, CityData> = {
     ],
     events: [ { id: "festival", title: "Wangala Festival", date: "2025-11-12", desc: "Harvest festival of the Garo tribe with dance and music." },
     { id: "eco", title: "Cherrapunji Eco Tourism Fair", date: "2025-05-18", desc: "Promoting eco-tourism and local culture." },],
+    restaurants: [
+      {
+        id: "orange_roots",
+        name: "Orange Roots",
+        cuisine: "Khasi vegetarian",
+        price: "₹₹",
+        rating: 4.6,
+        signature: "Bamboo shoot curry with smoked chili",
+        img: { uri: "https://images.unsplash.com/photo-1504753793650-d4a2b783c15e?q=80&w=800" },
+      },
+      {
+        id: "nok_a",
+        name: "Nok-a Restaurant",
+        cuisine: "North-eastern grill",
+        price: "₹₹",
+        rating: 4.5,
+        signature: "Smoked pork with fern shoots",
+        img: { uri: "https://images.unsplash.com/photo-1504674900247-0877df9cc836?q=80&w=800" },
+      },
+      {
+        id: "sohra_plaza",
+        name: "Sohra Plaza",
+        cuisine: "Multi-cuisine",
+        price: "₹₹",
+        rating: 4.3,
+        signature: "Jadoh rice bowls with spicy chutneys",
+        img: { uri: "https://images.unsplash.com/photo-1604908554200-0e327610e23b?q=80&w=800" },
+      },
+      {
+        id: "cafe_cherrapunjee",
+        name: "Cafe Cherrapunjee",
+        cuisine: "Coffee & bakes",
+        price: "₹₹",
+        rating: 4.4,
+        signature: "Cloud cheesecake with passionfruit glaze",
+        img: { uri: "https://images.unsplash.com/photo-1548943487-a2e4e43b4853?q=80&w=800" },
+      },
+    ],
   },
 
   tuscany: {
@@ -263,6 +501,44 @@ export const CITY_DATA: Record<string, CityData> = {
     ],
     events: [{ id: "palio", title: "Palio di Siena", date: "2025-07-02", desc: "Historic horse race in Siena’s Piazza del Campo." },
     { id: "wine", title: "Chianti Wine Festival", date: "2025-09-10", desc: "Celebration of Tuscany’s famous wines." },],
+    restaurants: [
+      {
+        id: "osteria_francescana",
+        name: "Osteria Francescana",
+        cuisine: "Avant-garde Italian",
+        price: "€€€€",
+        rating: 4.9,
+        signature: "Five ages of Parmigiano Reggiano",
+        img: { uri: "https://images.unsplash.com/photo-1525755662778-989d0524087e?q=80&w=800" },
+      },
+      {
+        id: "la_giostra",
+        name: "La Giostra",
+        cuisine: "Tuscan trattoria",
+        price: "€€€",
+        rating: 4.7,
+        signature: "Pappardelle al cinghiale with wild boar ragù",
+        img: { uri: "https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?q=80&w=800" },
+      },
+      {
+        id: "mercato_centrale",
+        name: "Mercato Centrale",
+        cuisine: "Gourmet food hall",
+        price: "€€",
+        rating: 4.6,
+        signature: "Porchetta panini with salsa verde",
+        img: { uri: "https://images.unsplash.com/photo-1525755662778-989d0524087e?q=80&w=800" },
+      },
+      {
+        id: "enoteca_pinchiorri",
+        name: "Enoteca Pinchiorri",
+        cuisine: "Fine dining",
+        price: "€€€€",
+        rating: 4.8,
+        signature: "Wine-paired tasting featuring Tuscan truffles",
+        img: { uri: "https://images.unsplash.com/photo-1541542684-4a8e77b1015f?q=80&w=800" },
+      },
+    ],
   },
 
   zurich: {
@@ -293,6 +569,44 @@ export const CITY_DATA: Record<string, CityData> = {
     ],
     events: [{ id: "street", title: "Street Parade", date: "2025-08-02", desc: "One of the largest techno parades in the world." },
     { id: "fest", title: "Sechseläuten", date: "2025-04-14", desc: "Spring festival with the burning of the Böögg." },],
+    restaurants: [
+      {
+        id: "haus_hiltl",
+        name: "Haus Hiltl",
+        cuisine: "Plant-based buffet",
+        price: "CHF CHF",
+        rating: 4.6,
+        signature: "Endless vegetarian buffet since 1898",
+        img: { uri: "https://images.unsplash.com/photo-1466978913421-dad2ebd01d17?q=80&w=800" },
+      },
+      {
+        id: "kronenhalle",
+        name: "Restaurant Kronenhalle",
+        cuisine: "Swiss classics",
+        price: "CHF CHF CHF",
+        rating: 4.7,
+        signature: "Zürcher Geschnetzeltes with rösti",
+        img: { uri: "https://images.unsplash.com/photo-1498837167922-ddd27525d352?q=80&w=800" },
+      },
+      {
+        id: "alpenrose",
+        name: "Alpenrose",
+        cuisine: "Alpine tavern",
+        price: "CHF CHF",
+        rating: 4.5,
+        signature: "Fondue moitié-moitié with mountain cheese",
+        img: { uri: "https://images.unsplash.com/photo-1528715471579-d1bcf0ba5e83?q=80&w=800" },
+      },
+      {
+        id: "laSalle",
+        name: "LaSalle",
+        cuisine: "Contemporary European",
+        price: "CHF CHF CHF",
+        rating: 4.4,
+        signature: "Charred octopus with saffron risotto",
+        img: { uri: "https://images.unsplash.com/photo-1504674900247-0877df9cc836?q=80&w=800" },
+      },
+    ],
   },
 
   himalayas: {
@@ -321,8 +635,58 @@ export const CITY_DATA: Record<string, CityData> = {
         img: require("../../../assets/images/h3.webp"),
       },
     ],
-    events: [    { id: "trek", title: "Himalayan Adventure Festival", date: "2025-06-20", desc: "Celebration of trekking, climbing, and outdoor life." },
-    { id: "spiti", title: "Spiti Tribal Fair", date: "2025-09-05", desc: "Showcasing culture and traditions of Spiti Valley." },],
+    events: [
+      {
+        id: "trek",
+        title: "Himalayan Adventure Festival",
+        date: "2025-06-20",
+        desc: "Celebration of trekking, climbing, and outdoor life.",
+      },
+      {
+        id: "spiti",
+        title: "Spiti Tribal Fair",
+        date: "2025-09-05",
+        desc: "Showcasing culture and traditions of Spiti Valley.",
+      },
+    ],
+    restaurants: [
+      {
+        id: "cafe_1947",
+        name: "Cafe 1947",
+        cuisine: "Italian & Himalayan",
+        price: "₹₹",
+        rating: 4.5,
+        signature: "Trout amritsari with herbed butter",
+        img: { uri: "https://images.unsplash.com/photo-1493770348161-369560ae357d?q=80&w=800" },
+      },
+      {
+        id: "rice_bowl",
+        name: "The Rice Bowl",
+        cuisine: "Tibetan & Chinese",
+        price: "₹₹",
+        rating: 4.4,
+        signature: "Thenthuk noodles with yak butter",
+        img: { uri: "https://images.unsplash.com/photo-1447078806655-40579c2520d6?q=80&w=800" },
+      },
+      {
+        id: "moonpeak",
+        name: "Moonpeak Espresso",
+        cuisine: "Cafe fare",
+        price: "₹₹",
+        rating: 4.6,
+        signature: "Himalayan honey cake with coffee",
+        img: { uri: "https://images.unsplash.com/photo-1512058564366-18510be2db19?q=80&w=800" },
+      },
+      {
+        id: "yak_farm",
+        name: "The Yak Farm",
+        cuisine: "Farm-to-table",
+        price: "₹₹₹",
+        rating: 4.7,
+        signature: "Slow-braised yak momos with chili oil",
+        img: { uri: "https://images.unsplash.com/photo-1515003197210-e0cd71810b5f?q=80&w=800" },
+      },
+    ],
   },
 
   tokyo: {
@@ -353,6 +717,44 @@ export const CITY_DATA: Record<string, CityData> = {
     ],
     events: [{ id: "sakura", title: "Cherry Blossom Festival", date: "2025-04-01", desc: "Viewing of blooming sakura trees across Tokyo." },
     { id: "anime", title: "Tokyo Anime Fair", date: "2025-03-18", desc: "One of the largest anime conventions worldwide." },],
+    restaurants: [
+      {
+        id: "sushi_saito",
+        name: "Sushi Saito",
+        cuisine: "Edomae sushi",
+        price: "¥¥¥¥",
+        rating: 4.9,
+        signature: "Omakase nigiri at a six-seat counter",
+        img: { uri: "https://images.unsplash.com/photo-1553621042-f6e147245754?q=80&w=800" },
+      },
+      {
+        id: "ichiran",
+        name: "Ichiran Shibuya",
+        cuisine: "Tonkotsu ramen",
+        price: "¥¥",
+        rating: 4.5,
+        signature: "Customizable solo-booth ramen experience",
+        img: { uri: "https://images.unsplash.com/photo-1543353071-873f17a7a088?q=80&w=800" },
+      },
+      {
+        id: "afuri",
+        name: "Afuri Ebisu",
+        cuisine: "Yuzu ramen",
+        price: "¥¥",
+        rating: 4.6,
+        signature: "Yuzu shio ramen with citrus aroma",
+        img: { uri: "https://images.unsplash.com/photo-1525755662778-989d0524087e?q=80&w=800" },
+      },
+      {
+        id: "gyukatsu",
+        name: "Gyukatsu Motomura",
+        cuisine: "Beef katsu",
+        price: "¥¥",
+        rating: 4.7,
+        signature: "Crisp gyukatsu finished on a personal grill",
+        img: { uri: "https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?q=80&w=800" },
+      },
+    ],
   },
 };
 // --------------------------------------------------------------------------------------------------
@@ -369,6 +771,7 @@ export default function CityScreen() {
 
   const city = useMemo(() => CITY_DATA[slug], [slug]);
   const places = city?.places ?? [];
+  const restaurants = city?.restaurants ?? [];
 
   if (!city) {
     return (
@@ -449,6 +852,55 @@ export default function CityScreen() {
               </TouchableOpacity>
             ))}
           </View>
+
+          {restaurants.length > 0 && (
+            <>
+              <View style={[s.sectionHeader, { marginTop: 8 }]}>
+                <Text style={s.sectionTitle}>Savor the city</Text>
+                <Text style={s.sectionSubtitle}>
+                  Reserve a table at buzz-worthy kitchens curated for unforgettable nights out.
+                </Text>
+              </View>
+
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={s.restaurantsScroll}
+              >
+                {restaurants.map((spot) => (
+                  <View key={spot.id} style={s.restaurantCard}>
+                    <ImageBackground
+                      source={spot.img || RESTAURANT_PLACEHOLDER}
+                      style={s.restaurantImage}
+                      imageStyle={s.restaurantImageRadius}
+                    >
+                      <LinearGradient
+                        colors={["rgba(15, 23, 42, 0.05)", "rgba(15, 23, 42, 0.95)"]}
+                        start={{ x: 0, y: 0 }}
+                        end={{ x: 0, y: 1 }}
+                        style={s.restaurantOverlay}
+                      >
+                        <View style={s.restaurantTopRow}>
+                          <Text style={s.restaurantBadge}>{spot.price}</Text>
+                        </View>
+                        <View style={s.restaurantDetails}>
+                          <Text style={s.restaurantName}>{spot.name}</Text>
+                          <Text style={s.restaurantCuisine}>{spot.cuisine}</Text>
+                          <View style={s.restaurantMeta}>
+                            <Text style={s.restaurantRating}>⭐ {spot.rating.toFixed(1)}</Text>
+                            <Text style={s.restaurantDivider}>•</Text>
+                            <Text style={s.restaurantSignature} numberOfLines={2}>
+                              {spot.signature}
+                            </Text>
+                          </View>
+                        </View>
+                      </LinearGradient>
+                    </ImageBackground>
+                  </View>
+                ))}
+              </ScrollView>
+            </>
+          )}
 
           <View style={s.sectionHeader}>
             <Text style={s.sectionTitle}>Plan your trip</Text>
@@ -600,6 +1052,37 @@ const s = StyleSheet.create({
     paddingVertical: 6,
   },
   placeMetaText: { color: "#60a5fa", fontWeight: "600", fontSize: 13, letterSpacing: 0.2 },
+  restaurantsScroll: { paddingBottom: 6, paddingRight: 12, gap: 16 },
+  restaurantCard: {
+    width: 260,
+    marginRight: 16,
+    borderRadius: 28,
+    overflow: "hidden",
+    borderWidth: 1,
+    borderColor: "rgba(148, 163, 184, 0.2)",
+    backgroundColor: "rgba(15, 23, 42, 0.68)",
+  },
+  restaurantImage: { width: "100%", height: 220 },
+  restaurantImageRadius: { borderRadius: 28 },
+  restaurantOverlay: { flex: 1, justifyContent: "space-between", padding: 18 },
+  restaurantTopRow: { flexDirection: "row", justifyContent: "flex-end" },
+  restaurantBadge: {
+    backgroundColor: "rgba(15, 118, 110, 0.7)",
+    color: "#ccfbf1",
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    borderRadius: 999,
+    fontSize: 12,
+    fontWeight: "700",
+    overflow: "hidden",
+  },
+  restaurantDetails: { gap: 4 },
+  restaurantName: { fontSize: 20, fontWeight: "700", color: "#f8fafc" },
+  restaurantCuisine: { color: "#dbeafe", fontSize: 14 },
+  restaurantMeta: { flexDirection: "row", alignItems: "center", gap: 6, marginTop: 6, flexWrap: "wrap" },
+  restaurantRating: { color: "#facc15", fontWeight: "700" },
+  restaurantDivider: { color: "rgba(226, 232, 240, 0.75)", fontWeight: "700" },
+  restaurantSignature: { color: "#e2e8f0", flex: 1, flexWrap: "wrap", lineHeight: 18 },
   actions: { gap: 16, marginBottom: 24 },
   actionCard: { borderRadius: 24, overflow: "hidden" },
   actionGradient: {


### PR DESCRIPTION
## Summary
- extend city data with curated restaurant lineups for each destination
- add a "Savor the city" carousel on the city screen highlighting restaurant details and imagery
- style the new section with gradient overlays, badges, and ratings to match the premium travel aesthetic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e47cba81488330a4d099f742982b53