### PR TITLE
Add tests for home and itinerary experiences

### DIFF
--- a/__tests__/Events.test.tsx
+++ b/__tests__/Events.test.tsx
@@ -25,7 +25,7 @@ describe("EventsScreen", () => {
   it("renders event title and details (UI)", () => {
     const { getByText } = render(<EventsScreen />);
     expect(getByText("Royal Albert Concert")).toBeTruthy();
-    expect(getByText("📅\n2025-10-12")).toBeTruthy();
+    expect(getByText("2025-10-12")).toBeTruthy();
     expect(getByText("Classical music festival.")).toBeTruthy();
   });
 

--- a/__tests__/Home.test.tsx
+++ b/__tests__/Home.test.tsx
@@ -1,0 +1,159 @@
+import React from "react";
+import { Alert, Keyboard } from "react-native";
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+
+jest.mock("react-native-get-random-values", () => ({}));
+jest.mock("react-native-url-polyfill/auto", () => ({}));
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+jest.mock("@react-native-community/datetimepicker", () => ({
+  __esModule: true,
+  default: () => null,
+  DateTimePickerAndroid: { open: jest.fn() },
+}));
+
+jest.mock("expo-router", () => ({
+  useRouter: jest.fn(),
+}));
+const mockPush = jest.fn();
+const useRouterMock = require("expo-router").useRouter as jest.Mock;
+
+jest.mock("@react-navigation/native", () => ({
+  useFocusEffect: (callback: any) => callback(),
+}));
+
+const mockAuth = {
+  getSession: jest.fn(),
+  onAuthStateChange: jest.fn(() => ({ data: { subscription: { unsubscribe: jest.fn() } } })),
+  signInWithPassword: jest.fn(),
+  signUp: jest.fn(),
+  getUser: jest.fn(),
+};
+
+const fromChain: any = {};
+fromChain.select = jest.fn(() => fromChain);
+fromChain.eq = jest.fn(() => fromChain);
+fromChain.order = jest.fn();
+
+const mockSupabase = {
+  auth: mockAuth,
+  from: jest.fn(() => fromChain),
+};
+
+jest.mock("@supabase/supabase-js");
+const createClientMock = require("@supabase/supabase-js").createClient as jest.Mock;
+createClientMock.mockReturnValue(mockSupabase);
+
+jest.mock("../components/Hero", () => () => null);
+
+jest.mock("../lib/db", () => ({
+  db: {
+    getAllAsync: jest.fn(),
+  },
+}));
+
+const HomeModule = require("../app/(tabs)/index");
+const Home = HomeModule.default as React.ComponentType;
+const toSlug = HomeModule.toSlug as (s: string) => string;
+
+const { db } = require("../lib/db");
+const getAllAsyncMock = db.getAllAsync as jest.Mock;
+
+const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+const dismissSpy = jest.spyOn(Keyboard, "dismiss").mockImplementation(() => {});
+
+describe("Home screen", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    useRouterMock.mockReturnValue({ push: mockPush });
+    createClientMock.mockReturnValue(mockSupabase);
+    alertSpy.mockClear();
+    dismissSpy.mockClear();
+    mockAuth.getSession.mockReset();
+    mockAuth.signInWithPassword.mockReset();
+    mockAuth.signUp.mockReset();
+    mockAuth.getUser.mockReset();
+    mockAuth.getUser.mockResolvedValue({ data: { user: null } });
+    fromChain.select.mockClear();
+    fromChain.eq.mockClear();
+    fromChain.order.mockReset();
+    mockSupabase.from.mockClear();
+    getAllAsyncMock.mockReset();
+  });
+
+  it("renders inline auth when no session is present", async () => {
+    mockAuth.getSession.mockResolvedValue({ data: { session: null } });
+
+    const { getByText } = render(<Home />);
+
+    await waitFor(() => {
+      expect(getByText("Sign in to CityHop")).toBeTruthy();
+    });
+  });
+
+  it("allows toggling to sign up mode", async () => {
+    mockAuth.getSession.mockResolvedValue({ data: { session: null } });
+
+    const { getByText } = render(<Home />);
+
+    const toggle = await waitFor(() => getByText("New here? Create an account"));
+    fireEvent.press(toggle);
+
+    await waitFor(() => {
+      expect(getByText("Create your CityHop account")).toBeTruthy();
+    });
+  });
+
+  it("submits sign in credentials", async () => {
+    mockAuth.getSession.mockResolvedValue({ data: { session: null } });
+    mockAuth.signInWithPassword.mockResolvedValue({ error: null });
+
+    const { getByPlaceholderText, getByText } = render(<Home />);
+
+    const emailInput = await waitFor(() => getByPlaceholderText("Email"));
+    const passwordInput = getByPlaceholderText("Password");
+
+    fireEvent.changeText(emailInput, "traveler@example.com");
+    fireEvent.changeText(passwordInput, "secret");
+    fireEvent.press(getByText("Sign In"));
+
+    await waitFor(() => {
+      expect(mockAuth.signInWithPassword).toHaveBeenCalledWith({
+        email: "traveler@example.com",
+        password: "secret",
+      });
+    });
+  });
+
+  it("navigates to a city when searching", async () => {
+    mockAuth.getSession.mockResolvedValue({
+      data: {
+        session: {
+          user: { id: "1", user_metadata: { full_name: "Sky Wanderer" } },
+        },
+      },
+    });
+    mockAuth.getUser.mockResolvedValue({ data: { user: { id: "1" } } });
+    fromChain.order.mockResolvedValue({ data: [], error: null });
+    getAllAsyncMock.mockResolvedValue([{ count: 2 }]);
+
+    const { getByPlaceholderText, getByText } = render(<Home />);
+
+    const input = await waitFor(() => getByPlaceholderText("Search for a city or hidden gem"));
+    fireEvent.changeText(input, "Tokyo");
+    fireEvent.press(getByText("Search destinations"));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/city/Tokyo");
+    });
+  });
+
+  it("converts names to url-friendly slugs", () => {
+    expect(toSlug("New York City")).toBe("new-york-city");
+    expect(toSlug("  Zürich  ")).toBe("zürich");
+  });
+});

--- a/__tests__/Itinerary.test.tsx
+++ b/__tests__/Itinerary.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { Alert } from "react-native";
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+
+jest.mock("@react-navigation/native", () => ({
+  useFocusEffect: (callback: any) => callback(),
+}));
+
+jest.mock("../lib/db", () => ({
+  db: {
+    runAsync: jest.fn(),
+    getAllAsync: jest.fn(),
+  },
+}));
+
+import ItineraryPlanner, { formatDateRange, tripDuration } from "../app/itinerary";
+
+const { db } = require("../lib/db");
+const runAsyncMock = db.runAsync as jest.Mock;
+const getAllAsyncMock = db.getAllAsync as jest.Mock;
+
+const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+
+describe("Itinerary planner", () => {
+  beforeEach(() => {
+    runAsyncMock.mockReset();
+    getAllAsyncMock.mockReset();
+    alertSpy.mockClear();
+    getAllAsyncMock.mockResolvedValue([]);
+    runAsyncMock.mockResolvedValue(undefined);
+  });
+
+  it("loads saved itineraries on mount", async () => {
+    render(<ItineraryPlanner />);
+
+    await waitFor(() => {
+      expect(getAllAsyncMock).toHaveBeenCalledWith(
+        "SELECT id, title, destination, start_date, end_date, experiences, created_at FROM itineraries ORDER BY datetime(created_at) DESC"
+      );
+    });
+  });
+
+  it("shows an alert when the title is missing", async () => {
+    const { getByText } = render(<ItineraryPlanner />);
+
+    const saveButton = await waitFor(() => getByText("Save itinerary"));
+    fireEvent.press(saveButton);
+
+    expect(alertSpy).toHaveBeenCalledWith("Missing title", "Give your itinerary a memorable name.");
+  });
+
+  it("requires a destination before saving", async () => {
+    const { getByPlaceholderText, getByText } = render(<ItineraryPlanner />);
+
+    const titleInput = await waitFor(() => getByPlaceholderText("Trip title (e.g. Amalfi Coast escape)"));
+    fireEvent.changeText(titleInput, "Dream Trip");
+
+    fireEvent.press(getByText("Save itinerary"));
+
+    expect(alertSpy).toHaveBeenCalledWith("Destination needed", "Where are you heading?");
+  });
+
+  it("persists a plan and resets the form", async () => {
+    const { getByPlaceholderText, getByText } = render(<ItineraryPlanner />);
+
+    const titleInput = await waitFor(() => getByPlaceholderText("Trip title (e.g. Amalfi Coast escape)"));
+    const destinationInput = getByPlaceholderText("Primary destination");
+    const startInput = getByPlaceholderText("Start date (YYYY-MM-DD)");
+    const endInput = getByPlaceholderText("End date (YYYY-MM-DD)");
+    const experiencesInput = getByPlaceholderText(
+      "Signature experiences, dining reservations, hidden gems..."
+    );
+
+    fireEvent.changeText(titleInput, "  Alpine Retreat  ");
+    fireEvent.changeText(destinationInput, "Zurich");
+    fireEvent.changeText(startInput, "2025-03-01");
+    fireEvent.changeText(endInput, "2025-03-05");
+    fireEvent.changeText(experiencesInput, "Visit the old town");
+
+    const saveButton = getByText("Save itinerary");
+    fireEvent.press(saveButton);
+
+    await waitFor(() => {
+      expect(runAsyncMock).toHaveBeenCalledWith(
+        "INSERT INTO itineraries (title, destination, start_date, end_date, experiences) VALUES (?, ?, ?, ?, ?)",
+        ["Alpine Retreat", "Zurich", "2025-03-01", "2025-03-05", "Visit the old town"]
+      );
+      expect(alertSpy).toHaveBeenCalledWith("Saved", "Your itinerary has been added.");
+    });
+  });
+});
+
+describe("Itinerary helpers", () => {
+  it("formats date ranges", () => {
+    expect(formatDateRange(null, null)).toBe("Flexible dates");
+    expect(formatDateRange("2025-02-01", null)).toBe("Starting 2025-02-01");
+    expect(formatDateRange(null, "2025-02-14")).toBe("Wrapping up by 2025-02-14");
+    expect(formatDateRange("2025-02-01", "2025-02-14")).toBe("2025-02-01 → 2025-02-14");
+  });
+
+  it("computes trip durations", () => {
+    expect(tripDuration("2025-02-01", "2025-02-05")).toBe("5 days");
+    expect(tripDuration("2025-02-01", "2025-02-01")).toBe("1 day");
+    expect(tripDuration("invalid", "2025-02-05")).toBeNull();
+    expect(tripDuration("2025-02-01", null)).toBeNull();
+  });
+});

--- a/__tests__/UIComponents.test.tsx
+++ b/__tests__/UIComponents.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Text } from "react-native";
+import { fireEvent, render } from "@testing-library/react-native";
+import { Card, Divider, H1, H2, P, Pill, SectionTitle } from "../components/ui";
+
+describe("UI primitives", () => {
+  it("renders typography components", () => {
+    const { getByText } = render(
+      <>
+        <H1>Discover</H1>
+        <H2>Highlights</H2>
+        <P>Hidden gems</P>
+      </>
+    );
+
+    expect(getByText("Discover")).toBeTruthy();
+    expect(getByText("Highlights")).toBeTruthy();
+    expect(getByText("Hidden gems")).toBeTruthy();
+  });
+
+  it("wraps content inside a card", () => {
+    const { getByText } = render(
+      <Card>
+        <Text>Inside card</Text>
+      </Card>
+    );
+
+    expect(getByText("Inside card")).toBeTruthy();
+  });
+
+  it("handles pill presses", () => {
+    const onPress = jest.fn();
+    const { getByText } = render(<Pill label="Museums" onPress={onPress} />);
+
+    fireEvent.press(getByText("Museums"));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows section titles and dividers", () => {
+    const { getByText, toJSON } = render(
+      <>
+        <SectionTitle>Saved places</SectionTitle>
+        <Divider />
+      </>
+    );
+
+    expect(getByText("Saved places")).toBeTruthy();
+    expect(toJSON()).toMatchSnapshot();
+  });
+});

--- a/__tests__/ViewBookings.test.tsx
+++ b/__tests__/ViewBookings.test.tsx
@@ -19,14 +19,15 @@ describe("ViewBookings Screen", () => {
   it("renders heading with cityId (Unit)", async () => {
     const { getByText } = render(<BookingsScreen />);
     await waitFor(() => {
-      expect(getByText("📖 Bookings in Jaipur")).toBeTruthy();
+      expect(getByText("Bookings")).toBeTruthy();
+      expect(getByText("Manage stays and guest details in Jaipur")).toBeTruthy();
     });
   });
 
   it("shows message when no bookings exist (Unit)", async () => {
     const { getByText } = render(<BookingsScreen />);
     await waitFor(() => {
-      expect(getByText("No bookings found.")).toBeTruthy();
+      expect(getByText("No bookings yet")).toBeTruthy();
     });
   });
 });

--- a/__tests__/__snapshots__/UIComponents.test.tsx.snap
+++ b/__tests__/__snapshots__/UIComponents.test.tsx.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UI primitives shows section titles and dividers 1`] = `
+[
+  <Text
+    style={
+      [
+        {
+          "color": "#101828",
+          "fontSize": 16,
+          "fontWeight": "800",
+          "letterSpacing": 0.3,
+          "marginBottom": 8,
+          "marginTop": 20,
+        },
+        undefined,
+      ]
+    }
+  >
+    Saved places
+  </Text>,
+  <View
+    style={
+      [
+        {
+          "backgroundColor": "#E2E8F0",
+          "height": 1,
+          "marginVertical": 14,
+        },
+        undefined,
+      ]
+    }
+  />,
+]
+`;

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -66,7 +66,7 @@ const POPULAR: { name: string; emoji: string }[] = [
 ];
 
 // util
-const toSlug = (s: string) => s.toLowerCase().trim().replace(/\s+/g, "-");
+export const toSlug = (s: string) => s.toLowerCase().trim().replace(/\s+/g, "-");
 
 // type for saved rows
 type SavedRow = {

--- a/app/itinerary.tsx
+++ b/app/itinerary.tsx
@@ -29,6 +29,23 @@ type Itinerary = {
 
 const gradientColors = ["#141E30", "#243B55", "#1F2937"];
 
+export function formatDateRange(start?: string | null, end?: string | null) {
+  if (!start && !end) return "Flexible dates";
+  if (start && !end) return `Starting ${start}`;
+  if (!start && end) return `Wrapping up by ${end}`;
+  return `${start} → ${end}`;
+}
+
+export function tripDuration(start?: string | null, end?: string | null) {
+  if (!start || !end) return null;
+  const startTime = new Date(start).getTime();
+  const endTime = new Date(end).getTime();
+  if (Number.isNaN(startTime) || Number.isNaN(endTime)) return null;
+  const diff = Math.max(0, Math.round((endTime - startTime) / (1000 * 60 * 60 * 24)) + 1);
+  if (!diff) return null;
+  return `${diff} day${diff === 1 ? "" : "s"}`;
+}
+
 export default function ItineraryPlanner() {
   const [title, setTitle] = useState("");
   const [destination, setDestination] = useState("");
@@ -116,23 +133,6 @@ export default function ItineraryPlanner() {
     if (plans.length === 1) return "One beautiful adventure awaits";
     return `${plans.length} crafted journeys ready to explore`;
   }, [plans.length]);
-
-  const formatDateRange = (start?: string | null, end?: string | null) => {
-    if (!start && !end) return "Flexible dates";
-    if (start && !end) return `Starting ${start}`;
-    if (!start && end) return `Wrapping up by ${end}`;
-    return `${start} → ${end}`;
-  };
-
-  const tripDuration = (start?: string | null, end?: string | null) => {
-    if (!start || !end) return null;
-    const startTime = new Date(start).getTime();
-    const endTime = new Date(end).getTime();
-    if (Number.isNaN(startTime) || Number.isNaN(endTime)) return null;
-    const diff = Math.max(0, Math.round((endTime - startTime) / (1000 * 60 * 60 * 24)) + 1);
-    if (!diff) return null;
-    return `${diff} day${diff === 1 ? "" : "s"}`;
-  };
 
   return (
     <LinearGradient colors={gradientColors} style={styles.gradient}>

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -19,8 +19,19 @@ jest.mock("@expo/vector-icons", () => {
   const React = require("react");
   const { Text } = require("react-native");
 
-  return {
-    Feather: ({ name = "", color, size = 16, style, ...rest }) =>
+  const ICON_LABELS: Record<string, string> = {
+    calendar: "📅",
+    "calendar-clear": "🗓",
+    "calendar-outline": "🗓",
+    "trash-outline": "🗑",
+    "create-outline": "✏️",
+    "bed-outline": "🛏",
+    "map": "🗺",
+    "sun": "☀️",
+  };
+
+  const createIcon = (setName: string) =>
+    ({ name = "", color, size = 16, style, ...rest }: any) =>
       React.createElement(
         Text,
         {
@@ -30,7 +41,11 @@ jest.mock("@expo/vector-icons", () => {
             style,
           ],
         },
-        `Feather:${name}`
-      ),
+        ICON_LABELS[name] ?? `${setName}:${name}`
+      );
+
+  return {
+    Feather: createIcon("Feather"),
+    Ionicons: createIcon("Ionicons"),
   };
 });


### PR DESCRIPTION
## Summary
- add Home screen tests covering auth flows, search navigation, and slug helper export
- exercise itinerary planner logic with database interactions and shared helpers in dedicated tests
- expand component coverage with UI primitive tests, snapshot, and adjust existing expectations plus icon mocks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e66c88afb083309d0b6e9b4378686b