### PR TITLE
Simplify home and booking UIs

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -23,7 +23,6 @@ import DateTimePicker, {
 import { Card, Pill, SectionTitle, Divider } from "../../components/ui";
 import Hero from "../../components/Hero";
 import { Colors, Spacing, Radius } from "../../theme";
-import { db } from "../../lib/db";
 
 // Polyfills (keep at top)
 import "react-native-get-random-values";
@@ -297,7 +296,6 @@ export default function Home() {
 
   // saved rows
   const [saved, setSaved] = useState<SavedRow[]>([]);
-  const [itineraryCount, setItineraryCount] = useState(0);
 
   useEffect(() => {
     (async () => {
@@ -321,12 +319,6 @@ export default function Home() {
         .then(({ data, error }) => { if (!error) setSaved(data || []); });
     });
 
-    db.getAllAsync<{ count: number | string }>("SELECT COUNT(*) as count FROM itineraries")
-      .then((rows) => setItineraryCount(Number(rows?.[0]?.count ?? 0) || 0))
-      .catch((error) => {
-        console.log("❌ Error loading itinerary count", error);
-        setItineraryCount(0);
-      });
   }, []);
 
   useFocusEffect(useCallback(() => { refreshHome(); }, [refreshHome]));
@@ -338,9 +330,6 @@ export default function Home() {
     ? SUGGEST.filter((c) => c.toLowerCase().startsWith(q.toLowerCase())).slice(0, 5)
     : SUGGEST.slice(0, 8);
 
-  const userName = session?.user?.user_metadata?.full_name as string | undefined;
-  const greeting = userName ? `Welcome back, ${userName.split(" ")[0]}!` : "Welcome back";
-  const subGreeting = "Let’s curate a bespoke city guide for your next getaway.";
   const suggestionHint = SUGGEST.slice(0, 3).join(", ");
 
   if (authLoading) {
@@ -365,16 +354,6 @@ export default function Home() {
 
       {/* Home content */}
       <View style={s.container}>
-        <View style={s.welcomeCard}>
-          <View style={{ flex: 1 }}>
-            <Text style={s.welcomeLabel}>{greeting}</Text>
-            <Text style={s.welcomeSubtitle}>{subGreeting}</Text>
-          </View>
-          <View style={s.welcomeBadge}>
-            <Feather name="compass" size={24} color="#fff" />
-          </View>
-        </View>
-
         <Card style={s.searchCard}>
           <Text style={s.searchTitle}>Where are we headed?</Text>
           <View style={s.searchRow}>
@@ -413,9 +392,7 @@ export default function Home() {
           style={s.itineraryLink}
         >
           <Feather name="calendar" size={20} color={Colors.primary} />
-          <Text style={s.itineraryLinkText}>
-            {`Itinerary${itineraryCount > 0 ? ` (${itineraryCount})` : ""}`}
-          </Text>
+          <Text style={s.itineraryLinkText}>Itinerary</Text>
         </TouchableOpacity>
 
         {/* Saved from Supabase */}
@@ -446,9 +423,7 @@ export default function Home() {
                       } as any)
                     }
                   >
-                    <View style={s.savedIconWrap}>
-                      <Feather name="bookmark" size={18} color={Colors.primary} />
-                    </View>
+                    <Feather name="bookmark" size={18} color={Colors.textDim} />
                     <View style={{ flex: 1, gap: 2 }}>
                       <Text style={s.savedTitle} numberOfLines={1}>{p.name}</Text>
                       {!!location && (
@@ -524,10 +499,6 @@ const s = StyleSheet.create({
   tileLabel: { color: Colors.text, fontWeight: "800", fontSize: 18, marginTop: Spacing.sm },
   signoutBtn: { ...rowCenter, marginTop: Spacing.xl, alignSelf: "center", backgroundColor: Colors.card, borderRadius: 999, paddingHorizontal: Spacing.lg, paddingVertical: Spacing.sm, gap: Spacing.xs, borderWidth: 1, borderColor: Colors.border },
   signoutText: { color: Colors.primary, fontWeight: "800" },
-  welcomeCard: { ...rowCenter, marginTop: -Spacing.xl, backgroundColor: Colors.card, padding: Spacing.lg, borderRadius: Radius.xl, gap: Spacing.lg, ...shadowBase, shadowRadius: 22 },
-  welcomeLabel: { fontSize: 22, fontWeight: "800", color: Colors.text },
-  welcomeSubtitle: { ...dimText, marginTop: Spacing.xs, lineHeight: 20 },
-  welcomeBadge: { ...center, width: 48, height: 48, borderRadius: 24, backgroundColor: Colors.primary },
   searchCard: { gap: Spacing.md },
   searchTitle: { fontSize: 18, fontWeight: "700", color: Colors.text },
   searchRow: { ...rowCenter, gap: Spacing.sm, borderWidth: 1, borderColor: Colors.border, borderRadius: Radius.lg, paddingHorizontal: Spacing.md, paddingVertical: Spacing.sm, backgroundColor: Colors.cardAlt },
@@ -550,7 +521,6 @@ const s = StyleSheet.create({
   tipText: { ...dimText, flex: 1 },
   savedList: { gap: Spacing.sm },
   savedItem: { ...rowCenter, gap: Spacing.md, backgroundColor: Colors.card, borderRadius: Radius.lg, paddingHorizontal: Spacing.md, paddingVertical: Spacing.sm + 2, borderWidth: 1, borderColor: Colors.border, ...shadowSoft },
-  savedIconWrap: { ...center, width: 28, height: 28 },
   savedTitle: { color: Colors.text, fontWeight: "700", fontSize: 15 },
   savedMeta: { ...dimText },
   sectionSubtitle: { ...dimText, marginBottom: Spacing.sm },

--- a/app/city/[cityId]/book.tsx
+++ b/app/city/[cityId]/book.tsx
@@ -1,5 +1,4 @@
 import { useLocalSearchParams } from "expo-router";
-import { LinearGradient } from "expo-linear-gradient";
 import { useState } from "react";
 import {
   Alert,
@@ -13,6 +12,7 @@ import {
   View,
 } from "react-native";
 import { db } from "../../../lib/db";
+import { Colors, Radius, Spacing } from "../../../theme";
 
 export default function BookHotel() {
   const { cityId, city } = useLocalSearchParams<{
@@ -53,116 +53,95 @@ export default function BookHotel() {
 
 
   return (
-    <LinearGradient colors={["#0f172a", "#0b1120", "#020617"]} style={s.gradient}>
+    <View style={s.container}>
       <KeyboardAvoidingView style={s.flex} behavior={Platform.OS === "ios" ? "padding" : undefined}>
         <ScrollView
           contentContainerStyle={s.scroll}
           keyboardShouldPersistTaps="handled"
           showsVerticalScrollIndicator={false}
         >
-          <View style={s.hero}>
-            <View style={s.heroAccent} />
-            <Text style={s.eyebrow}>Stay in style</Text>
-            <Text style={s.title}>Book a Hotel in {city}</Text>
-            <Text style={s.subtitle}>Personalize your stay with our curated partner properties.</Text>
+          <View style={s.header}>
+            <Text style={s.title}>Book a hotel in {city}</Text>
+            <Text style={s.subtitle}>Fill in your details below and we’ll save the reservation.</Text>
           </View>
 
-          <View style={s.formCard}>
-            <Text style={s.formLabel}>Guest details</Text>
+          <View style={s.section}>
+            <Text style={s.sectionLabel}>Guest details</Text>
             <TextInput
               style={s.input}
-              placeholder="Your Name"
-              placeholderTextColor="rgba(148, 163, 184, 0.8)"
+              placeholder="Your name"
+              placeholderTextColor={Colors.textDim}
               value={name}
               onChangeText={setName}
             />
             <TextInput
               style={s.input}
-              placeholder="Your Address"
-              placeholderTextColor="rgba(148, 163, 184, 0.8)"
+              placeholder="Your address"
+              placeholderTextColor={Colors.textDim}
               value={address}
               onChangeText={setAddress}
             />
           </View>
 
-          <View style={s.formCard}>
-            <Text style={s.formLabel}>Stay dates</Text>
+          <View style={s.section}>
+            <Text style={s.sectionLabel}>Stay dates</Text>
             <TextInput
               style={s.input}
-              placeholder="Start Date (YYYY-MM-DD)"
-              placeholderTextColor="rgba(148, 163, 184, 0.8)"
+              placeholder="Start date (YYYY-MM-DD)"
+              placeholderTextColor={Colors.textDim}
               value={start}
               onChangeText={setStart}
             />
             <TextInput
               style={s.input}
-              placeholder="End Date (YYYY-MM-DD)"
-              placeholderTextColor="rgba(148, 163, 184, 0.8)"
+              placeholder="End date (YYYY-MM-DD)"
+              placeholderTextColor={Colors.textDim}
               value={end}
               onChangeText={setEnd}
             />
           </View>
 
           <TouchableOpacity style={s.button} activeOpacity={0.9} onPress={saveBooking}>
-            <LinearGradient colors={["#ec4899", "#d946ef"]} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={s.buttonGradient}>
-              <Text style={s.buttonText}>Confirm Booking</Text>
-              <Text style={s.buttonHint}>Instant confirmation, no booking fees.</Text>
-            </LinearGradient>
+            <Text style={s.buttonText}>Confirm booking</Text>
           </TouchableOpacity>
         </ScrollView>
       </KeyboardAvoidingView>
-    </LinearGradient>
+    </View>
   );
 }
 
 const s = StyleSheet.create({
-  gradient: { flex: 1 },
+  container: { flex: 1, backgroundColor: Colors.bg },
   flex: { flex: 1 },
-  scroll: { padding: 24, paddingBottom: 60 },
-  hero: {
-    backgroundColor: "rgba(15, 23, 42, 0.7)",
-    borderRadius: 28,
-    padding: 24,
+  scroll: { padding: Spacing.lg, paddingBottom: Spacing.xl },
+  header: { gap: Spacing.xs, marginBottom: Spacing.lg },
+  title: { fontSize: 24, fontWeight: "700", color: Colors.text },
+  subtitle: { color: Colors.textDim, lineHeight: 20 },
+  section: {
+    backgroundColor: Colors.card,
+    borderRadius: Radius.md,
+    padding: Spacing.md,
     borderWidth: 1,
-    borderColor: "rgba(148, 163, 184, 0.18)",
-    marginBottom: 24,
-    overflow: "hidden",
+    borderColor: Colors.border,
+    marginBottom: Spacing.md,
+    gap: Spacing.sm,
   },
-  heroAccent: {
-    position: "absolute",
-    width: 220,
-    height: 220,
-    backgroundColor: "#ec4899",
-    opacity: 0.18,
-    borderRadius: 160,
-    right: -80,
-    top: -100,
-  },
-  eyebrow: { color: "#f472b6", textTransform: "uppercase", fontSize: 12, letterSpacing: 2, marginBottom: 8 },
-  title: { fontSize: 30, fontWeight: "800", color: "#f8fafc" },
-  subtitle: { color: "#cbd5e1", marginTop: 10, lineHeight: 20 },
-  formCard: {
-    backgroundColor: "rgba(15, 23, 42, 0.75)",
-    borderRadius: 24,
-    padding: 20,
-    borderWidth: 1,
-    borderColor: "rgba(148, 163, 184, 0.2)",
-    marginBottom: 20,
-  },
-  formLabel: { color: "#f8fafc", fontWeight: "700", fontSize: 16, marginBottom: 14 },
+  sectionLabel: { fontWeight: "600", color: Colors.text },
   input: {
-    backgroundColor: "rgba(15, 23, 42, 0.92)",
-    borderRadius: 16,
-    paddingHorizontal: 16,
-    paddingVertical: 14,
     borderWidth: 1,
-    borderColor: "rgba(148, 163, 184, 0.2)",
-    color: "#f8fafc",
-    fontSize: 16,
-    marginBottom: 12,
+    borderColor: Colors.border,
+    borderRadius: Radius.sm,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    color: Colors.text,
+    backgroundColor: Colors.cardAlt,
   },
-  button: { borderRadius: 24, overflow: "hidden" },
-  buttonGradient: { padding: 20, alignItems: "center" },
-  buttonText: { color: "#f8fafc", fontSize: 18, fontWeight: "700" },
-  buttonHint: { color: "#fdf2f8", marginTop: 6, fontSize: 13, opacity: 0.9 },
+  button: {
+    marginTop: Spacing.lg,
+    backgroundColor: Colors.primary,
+    borderRadius: Radius.md,
+    paddingVertical: Spacing.md,
+    alignItems: "center",
+  },
+  buttonText: { color: "#fff", fontWeight: "700", fontSize: 16 },
 });

--- a/app/city/[cityId]/bookings.tsx
+++ b/app/city/[cityId]/bookings.tsx
@@ -5,15 +5,12 @@ import {
   FlatList,
   Modal,
   SafeAreaView,
-  StatusBar,
   StyleSheet,
   Text,
   TextInput,
   TouchableOpacity,
   View,
 } from "react-native";
-import { Ionicons } from "@expo/vector-icons";
-import { LinearGradient } from "expo-linear-gradient";
 import { db } from "../../../lib/db";
 import { Colors, Radius, Spacing } from "../../../theme";
 
@@ -90,268 +87,151 @@ export default function BookingsScreen() {
 
 
   return (
-    <LinearGradient colors={[Colors.bg, Colors.bgAlt]} style={{ flex: 1 }}>
-      <StatusBar barStyle="dark-content" />
-      <SafeAreaView style={{ flex: 1 }}>
-        <View style={s.header}>
-          <View>
-            <Text style={s.heading}>Bookings</Text>
-            <Text style={s.subheading}>Manage stays and guest details in {cityId}</Text>
-          </View>
-          <View style={s.headerBadge}>
-            <Ionicons name="bed-outline" size={16} color={Colors.primary} />
-            <Text style={s.headerBadgeText}>{bookings.length} active</Text>
-          </View>
+    <SafeAreaView style={s.container}>
+      <View style={s.header}>
+        <Text style={s.heading}>Bookings</Text>
+        <Text style={s.subheading}>Manage stays in {cityId}</Text>
+      </View>
+
+      {bookings.length === 0 ? (
+        <View style={s.empty}>
+          <Text style={s.emptyTitle}>No bookings yet</Text>
+          <Text style={s.emptyText}>Add a reservation to see it listed here.</Text>
         </View>
+      ) : (
+        <FlatList
+          data={bookings}
+          keyExtractor={(item) => item.id.toString()}
+          contentContainerStyle={s.list}
+          ItemSeparatorComponent={() => <View style={s.separator} />}
+          renderItem={({ item }) => (
+            <View style={s.card}>
+              <Text style={s.cardTitle}>{item.hotel_name}</Text>
+              <Text style={s.cardMeta}>
+                {item.start_date} to {item.end_date}
+              </Text>
+              <Text style={s.cardMeta}>Guest: {item.customer_name}</Text>
+              <Text style={s.cardMeta}>Address: {item.customer_address}</Text>
 
-        {bookings.length === 0 ? (
-          <View style={s.emptyCard}>
-            <Ionicons name="calendar-clear" size={32} color={Colors.primary} />
-            <Text style={s.emptyTitle}>No bookings yet</Text>
-            <Text style={s.emptyText}>
-              When guests reserve a stay, their confirmation will appear here so you can edit or manage it on the go.
-            </Text>
-          </View>
-        ) : (
-          <FlatList
-            data={bookings}
-            keyExtractor={(item) => item.id.toString()}
-            contentContainerStyle={s.list}
-            renderItem={({ item }) => (
-              <View style={s.card}>
-                <View style={s.cardHeader}>
-                  <Text style={s.title}>{item.hotel_name}</Text>
-                  <View style={s.datePill}>
-                    <Ionicons name="calendar" size={14} color={Colors.primary} />
-                    <Text style={s.datePillText}>
-                      {item.start_date} → {item.end_date}
-                    </Text>
-                  </View>
-                </View>
-
-                <View style={s.rowItem}>
-                  <Ionicons name="person-circle-outline" size={18} color={Colors.textDim} />
-                  <Text style={s.bodyText}>{item.customer_name}</Text>
-                </View>
-                <View style={s.rowItem}>
-                  <Ionicons name="home-outline" size={18} color={Colors.textDim} />
-                  <Text style={s.bodyText}>{item.customer_address}</Text>
-                </View>
-
-                <View style={s.cardActions}>
-                  <TouchableOpacity style={[s.actionBtn, s.editBtn]} onPress={() => openEditModal(item)}>
-                    <Ionicons name="create-outline" size={18} color={"#fff"} />
-                    <Text style={s.actionText}>Edit</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[s.actionBtn, s.deleteBtn]}
-                    onPress={() =>
-                      Alert.alert("Delete booking?", "This action cannot be undone.", [
-                        { text: "Cancel", style: "cancel" },
-                        { text: "Delete", style: "destructive", onPress: () => deleteBooking(item.id) },
-                      ])
-                    }
-                  >
-                    <Ionicons name="trash-outline" size={18} color={"#fff"} />
-                    <Text style={s.actionText}>Delete</Text>
-                  </TouchableOpacity>
-                </View>
-              </View>
-            )}
-          />
-        )}
-
-        {/* ✏️ Edit Modal */}
-        <Modal visible={editModalVisible} animationType="slide" transparent>
-          <View style={s.modalWrap}>
-            <View style={s.modalContent}>
-              <View style={s.modalHeader}>
-                <Text style={s.modalTitle}>Edit booking</Text>
-                <TouchableOpacity onPress={() => setEditModalVisible(false)} style={s.modalClose}>
-                  <Ionicons name="close" size={20} color={Colors.textDim} />
+              <View style={s.cardActions}>
+                <TouchableOpacity style={s.linkBtn} onPress={() => openEditModal(item)}>
+                  <Text style={s.linkText}>Edit</Text>
                 </TouchableOpacity>
-              </View>
-
-              <TextInput
-                style={s.input}
-                value={name}
-                onChangeText={setName}
-                placeholder="Guest name"
-                placeholderTextColor={Colors.textDim}
-              />
-              <TextInput
-                style={s.input}
-                value={address}
-                onChangeText={setAddress}
-                placeholder="Guest address"
-                placeholderTextColor={Colors.textDim}
-              />
-              <View style={s.inputRow}>
-                <TextInput
-                  style={[s.input, { flex: 1 }]}
-                  value={start}
-                  onChangeText={setStart}
-                  placeholder="Start date"
-                  placeholderTextColor={Colors.textDim}
-                />
-                <View style={{ width: Spacing.sm }} />
-                <TextInput
-                  style={[s.input, { flex: 1 }]}
-                  value={end}
-                  onChangeText={setEnd}
-                  placeholder="End date"
-                  placeholderTextColor={Colors.textDim}
-                />
-              </View>
-
-              <View style={s.modalActions}>
-                <TouchableOpacity style={[s.modalBtn, s.cancelBtn]} onPress={() => setEditModalVisible(false)}>
-                  <Text style={s.cancelText}>Cancel</Text>
-                </TouchableOpacity>
-                <TouchableOpacity style={[s.modalBtn, s.saveBtn]} onPress={saveEdit}>
-                  <Text style={s.saveText}>Save changes</Text>
+                <TouchableOpacity
+                  style={s.linkBtn}
+                  onPress={() =>
+                    Alert.alert("Delete booking?", "This action cannot be undone.", [
+                      { text: "Cancel", style: "cancel" },
+                      { text: "Delete", style: "destructive", onPress: () => deleteBooking(item.id) },
+                    ])
+                  }
+                >
+                  <Text style={[s.linkText, { color: Colors.accent }]}>Delete</Text>
                 </TouchableOpacity>
               </View>
             </View>
+          )}
+        />
+      )}
+
+      <Modal visible={editModalVisible} animationType="fade" transparent>
+        <View style={s.modalWrap}>
+          <View style={s.modalContent}>
+            <Text style={s.modalTitle}>Edit booking</Text>
+
+            <TextInput
+              style={s.input}
+              value={name}
+              onChangeText={setName}
+              placeholder="Guest name"
+              placeholderTextColor={Colors.textDim}
+            />
+            <TextInput
+              style={s.input}
+              value={address}
+              onChangeText={setAddress}
+              placeholder="Guest address"
+              placeholderTextColor={Colors.textDim}
+            />
+            <TextInput
+              style={s.input}
+              value={start}
+              onChangeText={setStart}
+              placeholder="Start date"
+              placeholderTextColor={Colors.textDim}
+            />
+            <TextInput
+              style={s.input}
+              value={end}
+              onChangeText={setEnd}
+              placeholder="End date"
+              placeholderTextColor={Colors.textDim}
+            />
+
+            <View style={s.modalActions}>
+              <TouchableOpacity style={[s.modalBtn, s.cancelBtn]} onPress={() => setEditModalVisible(false)}>
+                <Text style={s.cancelText}>Cancel</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={[s.modalBtn, s.saveBtn]} onPress={saveEdit}>
+                <Text style={s.saveText}>Save</Text>
+              </TouchableOpacity>
+            </View>
           </View>
-        </Modal>
-      </SafeAreaView>
-    </LinearGradient>
+        </View>
+      </Modal>
+    </SafeAreaView>
   );
 }
 
 const s = StyleSheet.create({
-  header: {
-    paddingHorizontal: Spacing.lg,
-    paddingTop: Spacing.lg,
-    paddingBottom: Spacing.md,
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-  },
-  heading: { fontSize: 28, fontWeight: "800", color: Colors.text },
-  subheading: { color: Colors.textDim, marginTop: 4 },
-  headerBadge: {
-    backgroundColor: Colors.card,
-    borderRadius: 999,
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-    borderWidth: 1,
-    borderColor: Colors.border,
-  },
-  headerBadgeText: { color: Colors.primary, fontWeight: "700", fontSize: 12, textTransform: "uppercase" },
+  container: { flex: 1, backgroundColor: Colors.bg },
+  header: { paddingHorizontal: Spacing.lg, paddingTop: Spacing.lg, paddingBottom: Spacing.md, gap: 4 },
+  heading: { fontSize: 24, fontWeight: "700", color: Colors.text },
+  subheading: { color: Colors.textDim },
   list: { paddingHorizontal: Spacing.lg, paddingBottom: Spacing.xl },
-  emptyCard: {
-    marginHorizontal: Spacing.lg,
-    marginTop: Spacing.xl,
-    padding: Spacing.xl,
-    borderRadius: Radius.xl,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    backgroundColor: Colors.card,
+  separator: { height: Spacing.md },
+  empty: {
+    flex: 1,
     alignItems: "center",
-    gap: Spacing.md,
+    justifyContent: "center",
+    paddingHorizontal: Spacing.lg,
+    gap: Spacing.sm,
   },
-  emptyTitle: { fontSize: 20, fontWeight: "700", color: Colors.text },
-  emptyText: { color: Colors.textDim, textAlign: "center", lineHeight: 20 },
+  emptyTitle: { fontSize: 18, fontWeight: "600", color: Colors.text },
+  emptyText: { color: Colors.textDim, textAlign: "center" },
   card: {
     backgroundColor: Colors.card,
-    borderRadius: Radius.xl,
-    padding: Spacing.lg,
-    marginBottom: Spacing.lg,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    shadowColor: Colors.shadow,
-    shadowOpacity: 0.08,
-    shadowRadius: 18,
-    shadowOffset: { width: 0, height: 10 },
-    elevation: 3,
-  },
-  cardHeader: { flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start" },
-  title: { fontWeight: "700", fontSize: 18, color: Colors.text, flex: 1, paddingRight: Spacing.sm },
-  datePill: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-    backgroundColor: Colors.cardAlt,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 999,
-    borderWidth: 1,
-    borderColor: Colors.border,
-  },
-  datePillText: { color: Colors.text, fontWeight: "600", fontSize: 12 },
-  rowItem: { flexDirection: "row", alignItems: "center", gap: 10, marginTop: Spacing.sm },
-  bodyText: { color: Colors.text, flex: 1, lineHeight: 20 },
-  cardActions: { flexDirection: "row", gap: Spacing.sm, marginTop: Spacing.lg },
-  actionBtn: {
-    flex: 1,
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: 8,
-    paddingVertical: 12,
     borderRadius: Radius.md,
+    padding: Spacing.md,
+    borderWidth: 1,
+    borderColor: Colors.border,
   },
-  editBtn: { backgroundColor: Colors.primary },
-  deleteBtn: { backgroundColor: Colors.accent },
-  actionText: { color: "#fff", fontWeight: "700" },
-
-  modalWrap: {
-    flex: 1,
-    backgroundColor: "rgba(16,24,40,0.4)",
-    justifyContent: "center",
-    padding: Spacing.lg,
-  },
+  cardTitle: { fontWeight: "700", fontSize: 16, color: Colors.text },
+  cardMeta: { color: Colors.textDim, marginTop: 4 },
+  cardActions: { flexDirection: "row", justifyContent: "flex-end", gap: Spacing.md, marginTop: Spacing.md },
+  linkBtn: { paddingVertical: 4, paddingHorizontal: Spacing.xs },
+  linkText: { color: Colors.primary, fontWeight: "600" },
+  modalWrap: { flex: 1, backgroundColor: "rgba(0,0,0,0.25)", justifyContent: "center", padding: Spacing.lg },
   modalContent: {
     backgroundColor: Colors.card,
-    borderRadius: Radius.xl,
+    borderRadius: Radius.md,
     padding: Spacing.lg,
-    borderWidth: 1,
-    borderColor: Colors.border,
+    gap: Spacing.sm,
   },
-  modalHeader: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    marginBottom: Spacing.md,
-  },
-  modalTitle: { fontSize: 20, fontWeight: "800", color: Colors.text },
-  modalClose: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
-    alignItems: "center",
-    justifyContent: "center",
-    backgroundColor: Colors.cardAlt,
-  },
+  modalTitle: { fontSize: 18, fontWeight: "700", color: Colors.text },
   input: {
     borderWidth: 1,
     borderColor: Colors.border,
-    borderRadius: Radius.md,
+    borderRadius: Radius.sm,
     paddingHorizontal: Spacing.md,
-    paddingVertical: 12,
-    marginBottom: Spacing.sm,
+    paddingVertical: Spacing.sm,
     color: Colors.text,
     backgroundColor: Colors.cardAlt,
   },
-  inputRow: { flexDirection: "row" },
-  modalActions: {
-    flexDirection: "row",
-    justifyContent: "flex-end",
-    gap: Spacing.sm,
-    marginTop: Spacing.lg,
-  },
-  modalBtn: {
-    paddingVertical: 12,
-    paddingHorizontal: Spacing.lg,
-    borderRadius: Radius.md,
-  },
-  cancelBtn: { backgroundColor: Colors.cardAlt, borderWidth: 1, borderColor: Colors.border },
+  modalActions: { flexDirection: "row", justifyContent: "flex-end", gap: Spacing.sm, marginTop: Spacing.sm },
+  modalBtn: { paddingVertical: Spacing.sm, paddingHorizontal: Spacing.md, borderRadius: Radius.sm },
+  cancelBtn: { backgroundColor: Colors.cardAlt },
   saveBtn: { backgroundColor: Colors.primary },
-  cancelText: { color: Colors.text, fontWeight: "600" },
-  saveText: { color: "#fff", fontWeight: "700" },
+  cancelText: { color: Colors.text },
+  saveText: { color: "#fff", fontWeight: "600" },
 });

--- a/app/city/[cityId]/events.tsx
+++ b/app/city/[cityId]/events.tsx
@@ -1,8 +1,7 @@
 // app/city/[cityId]/events.tsx
 import { useLocalSearchParams } from "expo-router";
 import React, { useMemo } from "react";
-import { LinearGradient } from "expo-linear-gradient";
-import { FlatList, SafeAreaView, StatusBar, StyleSheet, Text, View } from "react-native";
+import { FlatList, StyleSheet, Text, View } from "react-native";
 import { CITY_DATA } from "./index"; // ✅ import from index.tsx
 import { Colors, Radius, Spacing } from "../../../theme";
 
@@ -17,137 +16,66 @@ export default function EventsScreen() {
 
   if (!city) {
     return (
-      <LinearGradient colors={["#0f172a", "#0b1120", "#020617"]} style={s.gradient}>
-        <StatusBar barStyle="light-content" />
-        <SafeAreaView style={s.safe}>
-          <View style={s.centerBox}>
-            <Text style={s.h1}>No data for {cityName || cityId}</Text>
-            <Text style={s.subtitle}>Try selecting another destination from the explore tab.</Text>
-          </View>
-        </SafeAreaView>
-      </LinearGradient>
+      <View style={s.container}>
+        <View style={s.empty}>
+          <Text style={s.title}>No details for {cityName || cityId}</Text>
+          <Text style={s.message}>Choose another city to browse upcoming events.</Text>
+        </View>
+      </View>
     );
   }
 
   if (events.length === 0) {
     return (
-      <LinearGradient colors={["#0f172a", "#0b1120", "#020617"]} style={s.gradient}>
-        <StatusBar barStyle="light-content" />
-        <SafeAreaView style={s.safe}>
-          <View style={s.centerBox}>
-            <Text style={s.h1}>Events in {city.name}</Text>
-            <Text style={s.subtitle}>We’re curating experiences here. Check back soon!</Text>
-          </View>
-        </SafeAreaView>
-      </LinearGradient>
+      <View style={s.container}>
+        <View style={s.empty}>
+          <Text style={s.title}>Events in {city.name}</Text>
+          <Text style={s.message}>We don’t have any happenings right now. Check back soon!</Text>
+        </View>
+      </View>
     );
   }
 
   return (
-    <LinearGradient colors={["#0f172a", "#0b1120", "#020617"]} style={s.gradient}>
-      <StatusBar barStyle="light-content" />
-      <SafeAreaView style={s.safe}>
-        <FlatList
-          contentContainerStyle={s.list}
-          data={events}
-          keyExtractor={(item) => item.id}
-          showsVerticalScrollIndicator={false}
-          ListHeaderComponent={() => (
-            <View style={s.heroCard}>
-              <View style={s.heroBadge}>
-                <Text style={s.badgeText}>City Spotlight</Text>
-              </View>
-              <Text style={s.heroTitle}>Events in {city.name}</Text>
-              <Text style={s.heroSubtitle}>
-                Make the most of your stay with curated happenings, live music, and pop-up culture moments.
-              </Text>
-            </View>
-          )}
-          ItemSeparatorComponent={() => <View style={{ height: 22 }} />}
-          renderItem={({ item, index }) => (
-            <View style={s.eventRow}>
-              <View style={s.timeline}>
-                <View style={s.timelineDot} />
-                {index !== events.length - 1 && <View style={s.timelineLine} />}
-              </View>
-              <View style={s.card}>
-                <Text style={s.date}>{item.date}</Text>
-                <Text style={s.title}>{item.title}</Text>
-                {!!item.desc && <Text style={s.desc}>{item.desc}</Text>}
-              </View>
-            </View>
-          )}
-        />
-      </SafeAreaView>
-    </LinearGradient>
+    <View style={s.container}>
+      <FlatList
+        data={events}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={s.list}
+        ItemSeparatorComponent={() => <View style={s.separator} />}
+        ListHeaderComponent={() => (
+          <View style={s.header}>
+            <Text style={s.title}>Events in {city.name}</Text>
+            <Text style={s.message}>Simple highlights to help you plan an outing.</Text>
+          </View>
+        )}
+        renderItem={({ item }) => (
+          <View style={s.card}>
+            <Text style={s.date}>{item.date}</Text>
+            <Text style={s.eventTitle}>{item.title}</Text>
+            {!!item.desc && <Text style={s.message}>{item.desc}</Text>}
+          </View>
+        )}
+      />
+    </View>
   );
 }
 
 const s = StyleSheet.create({
-  gradient: { flex: 1 },
-  safe: { flex: 1 },
-  list: { padding: Spacing.lg, paddingBottom: Spacing.xl },
-  centerBox: { flex: 1, alignItems: "center", justifyContent: "center", padding: Spacing.lg },
-  h1: { fontSize: 28, fontWeight: "800", color: "#f8fafc", textAlign: "center" },
-  subtitle: { color: "#94a3b8", marginTop: 10, lineHeight: 20, textAlign: "center" },
-
-  heroCard: {
-    backgroundColor: "rgba(15,23,42,0.65)",
-    padding: Spacing.lg,
-    borderRadius: Radius.xl,
-    borderWidth: 1,
-    borderColor: "rgba(148, 163, 184, 0.25)",
-    marginBottom: Spacing.lg,
-    shadowColor: "#000",
-    shadowOpacity: 0.25,
-    shadowRadius: 20,
-    shadowOffset: { width: 0, height: 10 },
-    elevation: 8,
-  },
-  heroBadge: {
-    alignSelf: "flex-start",
-    borderRadius: 999,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    backgroundColor: "rgba(59,130,246,0.25)",
-    marginBottom: Spacing.sm,
-  },
-  badgeText: { color: "#bfdbfe", fontWeight: "700", fontSize: 12, letterSpacing: 1 },
-  heroTitle: { fontSize: 30, fontWeight: "800", color: "#f8fafc" },
-  heroSubtitle: { color: "#cbd5f5", marginTop: Spacing.sm, lineHeight: 22 },
-
-  eventRow: { flexDirection: "row", alignItems: "stretch" },
-  timeline: { alignItems: "center", marginRight: Spacing.md },
-  timelineDot: {
-    width: 12,
-    height: 12,
-    borderRadius: 999,
-    backgroundColor: Colors.accent,
-    borderWidth: 3,
-    borderColor: "rgba(15,23,42,0.9)",
-    marginTop: 6,
-  },
-  timelineLine: {
-    flex: 1,
-    width: 2,
-    backgroundColor: "rgba(148,163,184,0.3)",
-    marginTop: 2,
-  },
+  container: { flex: 1, backgroundColor: Colors.bg },
+  list: { paddingHorizontal: Spacing.lg, paddingBottom: Spacing.xl },
+  separator: { height: Spacing.md },
+  header: { paddingHorizontal: Spacing.lg, paddingTop: Spacing.lg, paddingBottom: Spacing.md },
+  empty: { flex: 1, alignItems: "center", justifyContent: "center", padding: Spacing.lg, gap: Spacing.sm },
+  title: { fontSize: 24, fontWeight: "700", color: Colors.text },
+  message: { color: Colors.textDim, lineHeight: 20, textAlign: "center" },
   card: {
-    flex: 1,
-    backgroundColor: "rgba(15, 23, 42, 0.72)",
-    borderRadius: Radius.lg,
-    padding: Spacing.lg,
+    backgroundColor: Colors.card,
+    borderRadius: Radius.md,
+    padding: Spacing.md,
     borderWidth: 1,
-    borderColor: "rgba(148, 163, 184, 0.18)",
+    borderColor: Colors.border,
   },
-  title: { fontSize: 20, fontWeight: "700", color: "#f8fafc", marginTop: Spacing.xs },
-  date: {
-    color: Colors.accent,
-    fontWeight: "700",
-    fontSize: 14,
-    letterSpacing: 0.4,
-    textTransform: "uppercase",
-  },
-  desc: { color: "#cbd5e1", lineHeight: 20, marginTop: Spacing.sm },
+  date: { color: Colors.primary, fontWeight: "600", marginBottom: 4 },
+  eventTitle: { fontSize: 18, fontWeight: "700", color: Colors.text, marginBottom: 4 },
 });


### PR DESCRIPTION
## Summary
- remove the home welcome card, itinerary counter, and simplify the saved icon treatment
- replace gradients and decorative elements in the events, hotel booking, and bookings screens with lightweight layouts
- keep the existing data flows while presenting simpler copy blocks and buttons

## Testing
- `npm test -- --runTestsByPath __tests__/Events.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68f154c083408330afceedfc83194361